### PR TITLE
Ajout de Jpuyter Notebook au projet

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -44,6 +44,13 @@ if DEBUG:
         "10.0.2.2",
     ]
 
+    NOTEBOOK_ARGUMENTS = [
+        "--ip",
+        "0.0.0.0",
+        "--allow-root",
+        "--no-browser",
+    ]  # see https://stackoverflow.com/a/47063057/1892308
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -64,12 +71,6 @@ INSTALLED_APPS = [
     "xp",
     "django_extensions",
 ]
-
-NOTEBOOK_ARGUMENTS = [
-    '--ip', '0.0.0.0', 
-    '--allow-root',
-    '--no-browser', 
-] # see https://stackoverflow.com/a/47063057/1892308
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -62,7 +62,14 @@ INSTALLED_APPS = [
     "website",
     "api_alpha",
     "xp",
+    "django_extensions",
 ]
+
+NOTEBOOK_ARGUMENTS = [
+    '--ip', '0.0.0.0', 
+    '--allow-root',
+    '--no-browser', 
+] # see https://stackoverflow.com/a/47063057/1892308
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/app/notebooks/Requete en base.ipynb
+++ b/app/notebooks/Requete en base.ipynb
@@ -1,0 +1,381 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e1adb07d",
+   "metadata": {},
+   "source": [
+    "# Premiers tests de requêtes en base"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c015fe8e",
+   "metadata": {},
+   "source": [
+    "Quelques imports à faire avant toute chose"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2769d9af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from batid.models import Building\n",
+    "# necessary for SQL query execution from Jupyter\n",
+    "os.environ[\"DJANGO_ALLOW_ASYNC_UNSAFE\"] = \"true\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6178fc2",
+   "metadata": {},
+   "source": [
+    "## Compter les bâtiments dans le RNB\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fb560553",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "721294"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "entries_nb = Building.objects.count()\n",
+    "entries_nb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01bdd12f",
+   "metadata": {},
+   "source": [
+    "## Récupérer un bâtiment à partir de son RNB-id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "751cfc25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "building = Building.objects.get(rnb_id='QDLS5TEESYGR')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b1853d15",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SRID=2154;POINT (897010.1000000003 6476168.9)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(building.point)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f96fa752",
+   "metadata": {},
+   "source": [
+    "## Vérifier si un point se situe à l'intérieur d'un ou plusieurs bâtiments stockés dans le RNB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "4a91365e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ce point est situé dans 1 bâtiment(s) trouvé(s) dans le RNB\n"
+     ]
+    }
+   ],
+   "source": [
+    "from django.contrib.gis.geos import Point\n",
+    "point = Point(897010.1000000003, 6476168.9, srid=2154)\n",
+    "buildings = list(Building.objects.filter(shape__contains=point))\n",
+    "print(f\"ce point est situé dans {len(buildings)} bâtiment(s) trouvé(s) dans le RNB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9991154d",
+   "metadata": {},
+   "source": [
+    "Example de point en dehors de tout bâtiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "39d79669",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ce point est situé dans 0 bâtiment(s) trouvé(s) dans le RNB\n"
+     ]
+    }
+   ],
+   "source": [
+    "point = Point(890010.0, 6476168.9, srid=2154)\n",
+    "buildings = list(Building.objects.filter(shape__contains=point))\n",
+    "print(f\"ce point est situé dans {len(buildings)} bâtiment(s) trouvé(s) dans le RNB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee637a31",
+   "metadata": {},
+   "source": [
+    "## Trouver tous les bâtiments à moins de X mètres d'un point"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3140296b",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4 bâtiment(s) trouvé(s) dans un rayon de 100m autour du point\n"
+     ]
+    }
+   ],
+   "source": [
+    "from django.contrib.gis.measure import D # D is shortcut for distance\n",
+    "\n",
+    "point = Point(897010.1000000003, 6476168.9, srid=2154)\n",
+    "buildings = Building.objects.filter(shape__distance_lte=(point, 100))\n",
+    "print(f\"{len(buildings)} bâtiment(s) trouvé(s) dans un rayon de 100m autour du point\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "960be969",
+   "metadata": {},
+   "source": [
+    "Les ordonner par distance croissante"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "86d233ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "QDLS5TEESYGR à 0.0 mm\n",
+      "L3J12FEAKC5J à 10.700467280145181 mm\n",
+      "R3TC71BSLG1D à 70.98034939342104 mm\n",
+      "3L827UV22MDN à 88.99943820057138 mm\n"
+     ]
+    }
+   ],
+   "source": [
+    "from django.contrib.gis.db.models.functions import Distance\n",
+    "\n",
+    "point = Point(897010.1000000003, 6476168.9, srid=2154)\n",
+    "buildings = Building.objects.filter(shape__dwithin=(point, 100)).annotate(distance=Distance('shape', point)).order_by('distance')\n",
+    "for building in buildings:\n",
+    "    print(f\"{building.rnb_id} à {building.distance}m\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc04f58e",
+   "metadata": {},
+   "source": [
+    "## Accéder à la requête en base sous jacente"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "d1d17c62",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SELECT \"batid_building\".\"id\", \"batid_building\".\"rnb_id\", \"batid_building\".\"source\", \"batid_building\".\"point\"::bytea, \"batid_building\".\"shape\"::bytea, \"batid_building\".\"ext_bdnb_id\", \"batid_building\".\"ext_bdtopo_id\", \"batid_building\".\"created_at\", \"batid_building\".\"updated_at\", ST_Distance(\"batid_building\".\"shape\", ST_GeomFromEWKB('\\001\\001\\000\\000 j\\010\\000\\0006333\\344_+A\\232\\231\\2319b\\264XA'::bytea)) AS \"distance\" FROM \"batid_building\" WHERE ST_DWithin(\"batid_building\".\"shape\", ST_GeomFromEWKB('\\001\\001\\000\\000 j\\010\\000\\0006333\\344_+A\\232\\231\\2319b\\264XA'::bytea), 100) ORDER BY \"distance\" ASC\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = Building.objects.filter(shape__dwithin=(point, 100)).annotate(distance=Distance('shape', point)).order_by('distance').query\n",
+    "\n",
+    "print(query)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "286de69d",
+   "metadata": {},
+   "source": [
+    "## Trouver un bâtiment à partir d'une adresse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "1c6ff726",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[5.711453, 45.178974]\n",
+      "46\n"
+     ]
+    }
+   ],
+   "source": [
+    "import requests\n",
+    "\n",
+    "def get_coordinates_best_result(results):\n",
+    "    if len(results) == 0:\n",
+    "        return None\n",
+    "    \n",
+    "    best_result = results[0]\n",
+    "    geom = best_result['geometry']\n",
+    "    if geom['type'] == 'Point' and 'coordinates' in geom:\n",
+    "        print(geom['coordinates'])\n",
+    "        [lon, lat] = geom['coordinates']\n",
+    "        return [lon, lat]\n",
+    "    else:\n",
+    "        return None\n",
+    "\n",
+    "def geocode_address(address):\n",
+    "    url = f'https://api-adresse.data.gouv.fr/search/?q={address}'\n",
+    "    response = requests.get(url)\n",
+    "    data = response.json()\n",
+    "    results = data[\"features\"]\n",
+    "    best_result = get_coordinates_best_result(results)    \n",
+    "    return best_result\n",
+    "\n",
+    "def find_building_from_wgs_84_coordinates(lon, lat):\n",
+    "    point = Point(lon, lat, srid=4326)\n",
+    "    buildings = Building.objects.filter(shape__dwithin=(point, 100)).annotate(distance=Distance('shape', point)).order_by('distance')\n",
+    "    # print(buildings)\n",
+    "    print(len(buildings))\n",
+    "    return buildings[0]\n",
+    "\n",
+    "address = '1 Rue des Eaux Claires, Grenoble'\n",
+    "[lat, lon] = geocode_address(address)\n",
+    "building = find_building_from_wgs_84_coordinates(lat, lon)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "f30d28c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from ipyleaflet import Map, Marker, GeoJSON\n",
+    "\n",
+    "def show_map(geocoding_coordinates, building):\n",
+    "    [lat, lon] = geocoding_coordinates\n",
+    "    shape = building.shape\n",
+    "    shape_4326 = shape.transform(4326)\n",
+    "    geojson = json.loads(shape.geojson)\n",
+    "    center = (lon, lat)\n",
+    "    m = Map(center=center, zoom=17)\n",
+    "    marker = Marker(location=center, draggable=False)\n",
+    "    m.add_layer(marker);\n",
+    "    geo_json = GeoJSON(data=geojson)\n",
+    "    m.add_layer(geo_json)\n",
+    "    display(m)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "1bfbf795",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d38fe988077b43658ef3b2959e46f2dc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[45.178974, 5.711453], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "show_map([lat, lon], building)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Django Shell-Plus",
+   "language": "python",
+   "name": "django_extensions"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -66,3 +66,7 @@ watchdog==3.0.0
 wcwidth==0.2.6
 websocket-client==1.5.1
 whitenoise==6.4.0
+django-extensions==3.2.3
+ipython==8.15.0
+notebook==6.5.5 # see https://github.com/microsoft/azuredatastudio/issues/23945#issuecomment-1655543692
+traitlets==5.9.0 # see https://github.com/microsoft/azuredatastudio/issues/24436#issuecomment-1723328100

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
         target: app_web
     ports:
       - '8000:8000'
+      - '8888:8888'
     env_file:
       - ./.env.db_auth.dev
       - ./.env.app.dev


### PR DESCRIPTION
Ajout des Jupyter Notebooks dans le projet, ce qui permet de faire tourner les notebooks en ayant accès au code du projet et à la database.

Pour lancer le serveur Jupyter, il faut lancer la commande `python manage.py shell_plus --notebook` depuis le container web.