### PR TITLE
Permettre l'execution des tests en dehors de manage.py

### DIFF
--- a/app/api_alpha/__init__.py
+++ b/app/api_alpha/__init__.py
@@ -1,0 +1,32 @@
+# this is a temporary hack until unittest integration with VS Code is fixed
+# see https://github.com/Microsoft/vscode-python/issues/73#issuecomment-1334196634
+from django.conf import settings
+
+if not settings.configured:
+    import unittest
+    import os
+    from django import setup
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
+    setup()
+
+    from django.test.utils import (
+        setup_test_environment,
+        teardown_test_environment,
+        teardown_databases,
+        setup_databases,
+    )
+
+    VERBOSITY = 1
+    INTERACTIVE = False
+
+    def djangoSetUpTestRun(self):
+        setup_test_environment()
+        self._django_db_config = setup_databases(VERBOSITY, INTERACTIVE)
+
+    def djangoTearDownTestRun(self):
+        teardown_databases(self._django_db_config, VERBOSITY)
+        teardown_test_environment()
+
+    setattr(unittest.TestResult, "startTestRun", djangoSetUpTestRun)
+    setattr(unittest.TestResult, "stopTestRun", djangoTearDownTestRun)

--- a/app/batid/tests/__init__.py
+++ b/app/batid/tests/__init__.py
@@ -1,0 +1,32 @@
+# this is a temporary hack until unittest integration with VS Code is fixed
+# see https://github.com/Microsoft/vscode-python/issues/73#issuecomment-1334196634
+from django.conf import settings
+
+if not settings.configured:
+    import unittest
+    import os
+    from django import setup
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
+    setup()
+
+    from django.test.utils import (
+        setup_test_environment,
+        teardown_test_environment,
+        teardown_databases,
+        setup_databases,
+    )
+
+    VERBOSITY = 1
+    INTERACTIVE = False
+
+    def djangoSetUpTestRun(self):
+        setup_test_environment()
+        self._django_db_config = setup_databases(VERBOSITY, INTERACTIVE)
+
+    def djangoTearDownTestRun(self):
+        teardown_databases(self._django_db_config, VERBOSITY)
+        teardown_test_environment()
+
+    setattr(unittest.TestResult, "startTestRun", djangoSetUpTestRun)
+    setattr(unittest.TestResult, "stopTestRun", djangoTearDownTestRun)


### PR DESCRIPTION
Le contenu de ces __init__.py permet d'appeler les tests depuis unittest directement sans paser par `manage.py test`.
Ce qui permet en particulier de lancer les tests directement depuis VS Code et même de les debugger :nail_care: 

Ca m'a donné du mal mais je pense que ça sera pratique à l'avenir !

![image](https://github.com/fab-geocommuns/RNB-coeur/assets/15341118/afe1f656-d668-4195-829d-71b80153386d)
