### PR TITLE
Ajout de statistiques d'usage sur l'API

### DIFF
--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -15,9 +15,10 @@ from rest_framework.response import Response
 
 from django.http import HttpResponse, Http404
 from batid.services.vector_tiles import tile_sql, url_params_to_tile
+from rest_framework_tracking.mixins import LoggingMixin
 
 
-class BuildingViewSet(viewsets.ModelViewSet):
+class BuildingViewSet(LoggingMixin, viewsets.ModelViewSet):
     queryset = Building.objects.all()
     serializer_class = BuildingSerializer
     http_method_names = ["get"]
@@ -75,7 +76,7 @@ class BuildingViewSet(viewsets.ModelViewSet):
         return search.get_queryset()
 
 
-class ADSBatchViewSet(viewsets.ModelViewSet):
+class ADSBatchViewSet(LoggingMixin, viewsets.ModelViewSet):
     queryset = ADS.objects.all()
     serializer_class = ADSSerializer
     lookup_field = "file_number"
@@ -126,7 +127,7 @@ class ADSBatchViewSet(viewsets.ModelViewSet):
             raise ParseError({"errors": "No data in the request."})
 
 
-class ADSViewSet(viewsets.ModelViewSet):
+class ADSViewSet(LoggingMixin, viewsets.ModelViewSet):
     queryset = ADS.objects.all()
     serializer_class = ADSSerializer
     lookup_field = "file_number"

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -65,6 +65,7 @@ INSTALLED_APPS = [
     "rest_framework.authtoken",
     "django.contrib.postgres",
     "corsheaders",
+    "rest_framework_tracking",
     "batid",
     "website",
     "api_alpha",

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -137,3 +137,4 @@ webcolors==1.13
 webencodings==0.5.1
 websocket-client==1.5.1
 whitenoise==6.4.0
+drf-api-tracking==1.8.4


### PR DESCRIPTION
J'utilise le package drf-api-tracking ce qui permet assez facilement de tracker l'usage de notre API.
Les statistiques sont stockées en base et sont accessibles facilement depuis le panel admin du site, ce qui est pratique !

<img width="1195" alt="Capture d’écran 2023-10-11 à 17 46 59" src="https://github.com/fab-geocommuns/RNB-coeur/assets/15341118/d1bb533c-45a4-4aa5-ade4-e6c2c28a54b5">
