### PR TITLE
Montrer les scores dans le résultat de l'API

### DIFF
--- a/app/api_alpha/serializers.py
+++ b/app/api_alpha/serializers.py
@@ -43,10 +43,22 @@ class BuildingSerializer(serializers.ModelSerializer):
     # source = serializers.CharField(read_only=True)
     status = BuildingStatusSerializer(read_only=True, many=True)
     ext_bdtopo_id = serializers.CharField(read_only=True)
+    score = serializers.SerializerMethodField("get_score")
+
+    def __init__(self, *args, **kwargs):
+        query_params = kwargs["context"]["request"].query_params
+        # little bit hacky for the moment: we show the score only for point and address queries
+        if "point" not in query_params and "address" not in query_params:
+            del self.fields["score"]
+
+        super().__init__(*args, **kwargs)
+
+    def get_score(self, bdg):
+        return bdg.score
 
     class Meta:
         model = Building
-        fields = ["rnb_id", "status", "point", "addresses", "ext_bdtopo_id"]
+        fields = ["rnb_id", "status", "point", "addresses", "ext_bdtopo_id", "score"]
 
 
 class CityADSSerializer(serializers.ModelSerializer):

--- a/app/batid/services/search_bdg.py
+++ b/app/batid/services/search_bdg.py
@@ -217,7 +217,10 @@ class BuildingSearch:
             scores_sum = (
                 ", "
                 + " + ".join(self.scores.keys())
-                + " as score, "
+                # we divide the score by the max score to have a score between 0 and 1
+                + "::float / max("
+                + " + ".join(self.scores.keys())
+                + ") over() as score, "
                 + ", ".join(self.scores.keys())
             )
 
@@ -238,6 +241,8 @@ class BuildingSearch:
             f"{pagination_str}"
         )
 
+        print(global_query)
+
         qs = (
             Building.objects.raw(global_query, params)
             .prefetch_related("addresses")
@@ -247,7 +252,7 @@ class BuildingSearch:
         # print("---- QUERY ---")
         # print(qs.query)
 
-        return qs
+        return list(qs)
 
     def prepare_params(self):
         self.params.prepare_params()


### PR DESCRIPTION
C'est vraiment une solution temporaire, je m'arrange pour diviser le score de chaque batiment par le max des scores des batiments trouvés, ce qui fait que le meilleur batiment se retrouve avec un score de 1 et tous les autres avec 0 < score < 1.

Je fais aussi en sorte que les score n'apparaissent que lorsqu'on fait une requête de type "point" ou "adresse"