### PR TITLE
Detacher l'api batiment de BuildingSearch

### DIFF
--- a/app/api_alpha/tests/test_buildings.py
+++ b/app/api_alpha/tests/test_buildings.py
@@ -8,6 +8,8 @@ from rest_framework.test import APITestCase
 from batid.models import Building, BuildingStatus, User, Organization
 from rest_framework.authtoken.models import Token
 
+from batid.tests.helpers import create_grenoble, create_bdg
+
 
 class BuildingsEndpointsTest(APITestCase):
     def setUp(self) -> None:
@@ -68,11 +70,49 @@ class BuildingsEndpointsTest(APITestCase):
             happened_at=datetime.datetime(2020, 2, 1),
         )
 
+        # Check buildings in a city
+        create_grenoble()
+        bdg = create_bdg(
+            "INGRENOBLEGO",
+            [
+                [5.721187072129851, 45.18439363812283],
+                [5.721094925229238, 45.184330511384644],
+                [5.721122483180295, 45.184274061453465],
+                [5.721241326846666, 45.18428316628476],
+                [5.721244771590875, 45.184325048490564],
+                [5.7212697459849835, 45.18433718825423],
+                [5.721187072129851, 45.18439363812283],
+            ],
+        )
+        BuildingStatus.objects.create(
+            building=bdg,
+            type="constructed",
+            is_current=True,
+            happened_at=datetime.datetime(2023, 2, 1),
+        )
+
     def test_buildings_root(self):
         r = self.client.get("/api/alpha/buildings/")
         self.assertEqual(r.status_code, 200)
 
         expected = [
+            {
+                "addresses": [],
+                "ext_bdtopo_id": None,
+                "point": {
+                    "coordinates": [5.7211808330356, 45.18433388648706],
+                    "type": "Point",
+                },
+                "rnb_id": "INGRENOBLEGO",
+                "status": [
+                    {
+                        "happened_at": "2023-02-01",
+                        "is_current": True,
+                        "label": "Construit",
+                        "type": "constructed",
+                    }
+                ],
+            },
             {
                 "ext_bdtopo_id": None,
                 "rnb_id": "BDGSRNBBIDID",
@@ -89,10 +129,13 @@ class BuildingsEndpointsTest(APITestCase):
                     "coordinates": [1.065566769109709, 46.63416324688213],
                 },
                 "addresses": [],
-            }
+            },
         ]
 
         self.assertListEqual(r.json(), expected)
+
+    def test_bdg_in_city(self):
+        pass
 
     def test_one_bdg_with_dash(self):
         r = self.client.get("/api/alpha/buildings/BDGS-RNBB-IDID/")

--- a/app/api_alpha/tests/test_buildings.py
+++ b/app/api_alpha/tests/test_buildings.py
@@ -187,6 +187,23 @@ class BuildingsEndpointsWithAuthTest(BuildingsEndpointsTest):
 
         expected = [
             {
+                "addresses": [],
+                "ext_bdtopo_id": None,
+                "point": {
+                    "coordinates": [5.7211808330356, 45.18433388648706],
+                    "type": "Point",
+                },
+                "rnb_id": "INGRENOBLEGO",
+                "status": [
+                    {
+                        "happened_at": "2023-02-01",
+                        "is_current": True,
+                        "label": "Construit",
+                        "type": "constructed",
+                    }
+                ],
+            },
+            {
                 "ext_bdtopo_id": None,
                 "rnb_id": "BDGSRNBBIDID",
                 "point": {
@@ -222,7 +239,7 @@ class BuildingsEndpointsWithAuthTest(BuildingsEndpointsTest):
             },
         ]
 
-        self.assertEqual(len(data), 2)
+        self.assertEqual(len(data), 3)
         self.maxDiff = None
         self.assertListEqual(data, expected)
 

--- a/app/api_alpha/tests/test_buildings.py
+++ b/app/api_alpha/tests/test_buildings.py
@@ -91,6 +91,37 @@ class BuildingsEndpointsTest(APITestCase):
             happened_at=datetime.datetime(2023, 2, 1),
         )
 
+    def test_bdg_in_bbox(self):
+        r = self.client.get(
+            "/api/alpha/buildings/?bbox=45.18468473541278,5.7211808330356,45.18355043319679,5.722614035153486"
+        )
+        self.assertEqual(r.status_code, 200)
+
+        expected = [
+            {
+                "addresses": [],
+                "ext_bdtopo_id": None,
+                "point": {
+                    "coordinates": [5.7211808330356, 45.18433388648706],
+                    "type": "Point",
+                },
+                "rnb_id": "INGRENOBLEGO",
+                "status": [
+                    {
+                        "happened_at": "2023-02-01",
+                        "is_current": True,
+                        "label": "Construit",
+                        "type": "constructed",
+                    }
+                ],
+            }
+        ]
+
+        data = r.json()
+
+        self.assertEqual(len(data), 1)
+        self.assertListEqual(data, expected)
+
     def test_bdg_in_city(self):
         r = self.client.get("/api/alpha/buildings/?insee_code=38185")
         self.assertEqual(r.status_code, 200)

--- a/app/api_alpha/tests/test_buildings.py
+++ b/app/api_alpha/tests/test_buildings.py
@@ -91,6 +91,35 @@ class BuildingsEndpointsTest(APITestCase):
             happened_at=datetime.datetime(2023, 2, 1),
         )
 
+    def test_bdg_in_city(self):
+        r = self.client.get("/api/alpha/buildings/?insee_code=38185")
+        self.assertEqual(r.status_code, 200)
+
+        expected = [
+            {
+                "addresses": [],
+                "ext_bdtopo_id": None,
+                "point": {
+                    "coordinates": [5.7211808330356, 45.18433388648706],
+                    "type": "Point",
+                },
+                "rnb_id": "INGRENOBLEGO",
+                "status": [
+                    {
+                        "happened_at": "2023-02-01",
+                        "is_current": True,
+                        "label": "Construit",
+                        "type": "constructed",
+                    }
+                ],
+            }
+        ]
+
+        data = r.json()
+
+        self.assertEqual(len(data), 1)
+        self.assertListEqual(data, expected)
+
     def test_buildings_root(self):
         r = self.client.get("/api/alpha/buildings/")
         self.assertEqual(r.status_code, 200)
@@ -133,9 +162,6 @@ class BuildingsEndpointsTest(APITestCase):
         ]
 
         self.assertListEqual(r.json(), expected)
-
-    def test_bdg_in_city(self):
-        pass
 
     def test_one_bdg_with_dash(self):
         r = self.client.get("/api/alpha/buildings/BDGS-RNBB-IDID/")

--- a/app/api_alpha/tests/test_buildings.py
+++ b/app/api_alpha/tests/test_buildings.py
@@ -95,8 +95,8 @@ class BuildingsEndpointsTest(APITestCase):
         self.assertListEqual(r.json(), expected)
 
     def test_one_bdg_with_dash(self):
-        # r = self.client.get("/api/alpha/buildings/BDGS-RNBB-IDID/")
-        r = self.client.get("/api/alpha/buildings/BDGSRNBBIDID/")
+        r = self.client.get("/api/alpha/buildings/BDGS-RNBB-IDID/")
+        # r = self.client.get("/api/alpha/buildings/BDGSRNBBIDID/")
         self.assertEqual(r.status_code, 200)
 
         expected = {

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -3,6 +3,8 @@ from django.db import connection
 from api_alpha.permissions import ADSPermission
 from api_alpha.serializers import ADSSerializer, BuildingSerializer
 from api_alpha.services import get_city_from_request
+from batid.list_bdg import public_bdg_queryset, filter_bdg_queryset
+from batid.services.rnb_id import clean_rnb_id
 from batid.services.search_ads import ADSSearch
 from batid.services.search_bdg import BuildingSearch
 from batid.services.bdg_status import BuildingStatus as BuildingStatusModel
@@ -27,53 +29,15 @@ class BuildingViewSet(LoggingMixin, viewsets.ModelViewSet):
     pagination_class = None
 
     def get_object(self):
-        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
-
-        search = BuildingSearch()
-
-        search.set_params_from_url(**{"rnb_id": self.kwargs[lookup_url_kwarg]})
-
-        if not search.is_valid():
-            raise ParseError({"errors": search.errors})
-            return
-
-        qs = search.get_queryset()
-
-        if len(qs) == 0:
+        try:
+            return Building.objects.get(rnb_id=clean_rnb_id(self.kwargs["rnb_id"]))
+        except Building.DoesNotExist:
             raise Http404
-            return
-
-        obj = qs[0]
-
-        # May raise a permission denied
-        self.check_object_permissions(self.request, obj)
-
-        return obj
 
     def get_queryset(self):
-        search = BuildingSearch()
+        qs = public_bdg_queryset(self.request.user)
 
-        # If the user is authenticated, it has access to the full list of status
-        if self.request.user.is_authenticated:
-            search.params.allowed_status = BuildingStatusModel.ALL_TYPES_KEYS
-
-        # If we are listing buildings, the default status we display are those ones
-        if self.action == "list":
-            search.params.status = [
-                "ongoingConstruction",
-                "constructed",
-                "ongoingChange",
-                "notUsable",
-            ]
-
-        # Then we apply the filters requested by the user
-        search.set_params_from_url(**self.request.query_params.dict())
-
-        if not search.is_valid():
-            raise ParseError({"errors": search.errors})
-            return
-
-        return search.get_queryset()
+        return filter_bdg_queryset(qs, self.request.query_params)
 
 
 class ADSBatchViewSet(LoggingMixin, viewsets.ModelViewSet):

--- a/app/batid/list_bdg.py
+++ b/app/batid/list_bdg.py
@@ -9,4 +9,21 @@ def public_bdg_queryset(user=None) -> QuerySet:
     if user and user.is_authenticated:
         allowed_status = BuildingStatus.ALL_TYPES_KEYS
 
-    return Building.objects.filter(status__type__in=allowed_status)
+    return Building.objects.filter(status__type__in=allowed_status).order_by("-rnb_id")
+
+
+def filter_bdg_queryset(qs: QuerySet, params) -> QuerySet:
+    # Status filter
+    status = BuildingStatus.DEFAULT_DISPLAY_STATUS
+
+    query_status_str = params.get("status", None)
+
+    if query_status_str:
+        if query_status_str == "all":
+            status = BuildingStatus.ALL_TYPES_KEYS
+        else:
+            status = query_status_str.split(",")
+
+    qs = qs.filter(status__type__in=status)
+
+    return qs

--- a/app/batid/list_bdg.py
+++ b/app/batid/list_bdg.py
@@ -1,0 +1,12 @@
+from django.db.models import QuerySet
+from batid.services.bdg_status import BuildingStatus
+from batid.models import Building
+
+
+def public_bdg_queryset(user=None) -> QuerySet:
+    allowed_status = BuildingStatus.PUBLIC_TYPES_KEYS
+
+    if user and user.is_authenticated:
+        allowed_status = BuildingStatus.ALL_TYPES_KEYS
+
+    return Building.objects.filter(status__type__in=allowed_status)

--- a/app/batid/list_bdg.py
+++ b/app/batid/list_bdg.py
@@ -1,6 +1,7 @@
+from django.contrib.gis.geos import Polygon
 from django.db.models import QuerySet
 from batid.services.bdg_status import BuildingStatus
-from batid.models import Building
+from batid.models import Building, City
 
 
 def public_bdg_queryset(user=None) -> QuerySet:
@@ -13,6 +14,26 @@ def public_bdg_queryset(user=None) -> QuerySet:
 
 
 def filter_bdg_queryset(qs: QuerySet, params) -> QuerySet:
+    # Bounding box
+    bbox_str = params.get("bbox", None)
+    if bbox_str:
+        nw_lat, nw_lng, se_lat, se_lng = [float(coord) for coord in bbox_str.split(",")]
+        poly_coords = (
+            (nw_lng, nw_lat),
+            (nw_lng, se_lat),
+            (se_lng, se_lat),
+            (se_lng, nw_lat),
+            (nw_lng, nw_lat),
+        )
+        poly = Polygon(poly_coords, srid=4326)
+        qs = qs.filter(shape__intersects=poly)
+
+    # Insee Code filter
+    insee_code = params.get("insee_code", None)
+    if insee_code:
+        city = City.objects.get(code_insee=insee_code)
+        qs = qs.filter(shape__intersects=city.shape)
+
     # Status filter
     status = BuildingStatus.DEFAULT_DISPLAY_STATUS
 

--- a/app/batid/management/commands/sandbox.py
+++ b/app/batid/management/commands/sandbox.py
@@ -18,9 +18,12 @@ from django.db import connection
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        with connection.cursor() as cur:
-            q = "select * from batid_plot where id = 1"
-            cur.execute(q)
+        s = BuildingSearch()
+        s.set_params()
 
-            for row in cur.fetchall():
-                print(row)
+        results = s.get_queryset()
+
+        for b in results:
+            print("---------")
+            print(b.rnb_id)
+            print(b.point_geojson())

--- a/app/batid/models.py
+++ b/app/batid/models.py
@@ -3,8 +3,6 @@ import json
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import ArrayField
 from django.contrib.gis.db import models
-from django.contrib.postgres.indexes import SpGistIndex
-from django.utils.timezone import now
 from django.conf import settings
 from django.db.models import F
 from batid.services.bdg_status import BuildingStatus as BuildingStatusModel

--- a/app/batid/services/bdg_status.py
+++ b/app/batid/services/bdg_status.py
@@ -25,6 +25,14 @@ class BuildingStatus:
     PRIVATE_TYPES_KEYS = [s["key"] for s in TYPES if not s["public"]]
     ALL_TYPES_KEYS = [s["key"] for s in TYPES]
 
+    # Those are the default status display in the listing API
+    DEFAULT_DISPLAY_STATUS = [
+        "ongoingConstruction",
+        "constructed",
+        "ongoingChange",
+        "notUsable",
+    ]
+
     # Those are the status which trigger the creation of a "constructed" status
     # if the building does not have one
     POST_CONSTRUCTED_KEYS = [

--- a/app/batid/services/search_bdg.py
+++ b/app/batid/services/search_bdg.py
@@ -244,8 +244,8 @@ class BuildingSearch:
             .prefetch_related("status")
         )
 
-        print("---- QUERY ---")
-        print(qs.query)
+        # print("---- QUERY ---")
+        # print(qs.query)
 
         return qs
 

--- a/app/batid/services/search_bdg.py
+++ b/app/batid/services/search_bdg.py
@@ -244,8 +244,8 @@ class BuildingSearch:
             .prefetch_related("status")
         )
 
-        # print("---- QUERY ---")
-        # print(qs.query)
+        print("---- QUERY ---")
+        print(qs.query)
 
         return qs
 

--- a/app/notebooks/Prototype score pour rapprochement.ipynb
+++ b/app/notebooks/Prototype score pour rapprochement.ipynb
@@ -10,12 +10,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "id": "a10dae19",
    "metadata": {},
    "outputs": [],
    "source": [
     "from batid.models import Building\n",
+    "import os\n",
     "\n",
     "os.environ[\"DJANGO_ALLOW_ASYNC_UNSAFE\"] = \"true\""
    ]
@@ -30,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 3,
    "id": "1b5bc0f6",
    "metadata": {},
    "outputs": [
@@ -75,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 4,
    "id": "034540f6",
    "metadata": {},
    "outputs": [
@@ -129,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 5,
    "id": "e7c4a672",
    "metadata": {},
    "outputs": [
@@ -171,17 +172,67 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bd917f09",
+   "cell_type": "markdown",
+   "id": "b98f928a",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "## Combinaison de scores et tri sans sous-requête"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b152001f",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ProgrammingError",
+     "evalue": "column \"area_score\" does not exist\nLINE 1: SELECT id, rnb_id, area_score + x_score as score, CASE WHEN ...\n                           ^\n",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mUndefinedColumn\u001b[0m                           Traceback (most recent call last)",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/django/db/backends/utils.py:89\u001b[0m, in \u001b[0;36mCursorWrapper._execute\u001b[0;34m(self, sql, params, *ignored_wrapper_args)\u001b[0m\n\u001b[1;32m     88\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m---> 89\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcursor\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43msql\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mparams\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[0;31mUndefinedColumn\u001b[0m: column \"area_score\" does not exist\nLINE 1: SELECT id, rnb_id, area_score + x_score as score, CASE WHEN ...\n                           ^\n",
+      "\nThe above exception was the direct cause of the following exception:\n",
+      "\u001b[0;31mProgrammingError\u001b[0m                          Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[7], line 12\u001b[0m\n\u001b[1;32m      1\u001b[0m q \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m      2\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mSELECT id, rnb_id, area_score + x_score as score, \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m      3\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mCASE WHEN ST_Area(shape) > 100 THEN 1 ELSE 0 END AS area_score, \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m      7\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mLIMIT 10\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m      8\u001b[0m )\n\u001b[1;32m     10\u001b[0m qs \u001b[38;5;241m=\u001b[39m Building\u001b[38;5;241m.\u001b[39mobjects\u001b[38;5;241m.\u001b[39mraw(q)\n\u001b[0;32m---> 12\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m b \u001b[38;5;129;01min\u001b[39;00m qs:\n\u001b[1;32m     13\u001b[0m     \u001b[38;5;28mprint\u001b[39m(b\u001b[38;5;241m.\u001b[39mrnb_id, b\u001b[38;5;241m.\u001b[39mscore)\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/django/db/models/query.py:2057\u001b[0m, in \u001b[0;36mRawQuerySet.__iter__\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m   2056\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__iter__\u001b[39m(\u001b[38;5;28mself\u001b[39m):\n\u001b[0;32m-> 2057\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_fetch_all\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   2058\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28miter\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_result_cache)\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/django/db/models/query.py:2044\u001b[0m, in \u001b[0;36mRawQuerySet._fetch_all\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m   2042\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_fetch_all\u001b[39m(\u001b[38;5;28mself\u001b[39m):\n\u001b[1;32m   2043\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_result_cache \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m-> 2044\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_result_cache \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mlist\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43miterator\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   2045\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_prefetch_related_lookups \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_prefetch_done:\n\u001b[1;32m   2046\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_prefetch_related_objects()\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/django/db/models/query.py:2071\u001b[0m, in \u001b[0;36mRawQuerySet.iterator\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m   2070\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21miterator\u001b[39m(\u001b[38;5;28mself\u001b[39m):\n\u001b[0;32m-> 2071\u001b[0m     \u001b[38;5;28;01myield from\u001b[39;00m RawModelIterable(\u001b[38;5;28mself\u001b[39m)\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/django/db/models/query.py:154\u001b[0m, in \u001b[0;36mRawModelIterable.__iter__\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    152\u001b[0m connection \u001b[38;5;241m=\u001b[39m connections[db]\n\u001b[1;32m    153\u001b[0m compiler \u001b[38;5;241m=\u001b[39m connection\u001b[38;5;241m.\u001b[39mops\u001b[38;5;241m.\u001b[39mcompiler(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mSQLCompiler\u001b[39m\u001b[38;5;124m\"\u001b[39m)(query, connection, db)\n\u001b[0;32m--> 154\u001b[0m query_iterator \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43miter\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mquery\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    156\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m    157\u001b[0m     (\n\u001b[1;32m    158\u001b[0m         model_init_names,\n\u001b[1;32m    159\u001b[0m         model_init_pos,\n\u001b[1;32m    160\u001b[0m         annotation_fields,\n\u001b[1;32m    161\u001b[0m     ) \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mqueryset\u001b[38;5;241m.\u001b[39mresolve_model_init_order()\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/django/db/models/sql/query.py:112\u001b[0m, in \u001b[0;36mRawQuery.__iter__\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    109\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__iter__\u001b[39m(\u001b[38;5;28mself\u001b[39m):\n\u001b[1;32m    110\u001b[0m     \u001b[38;5;66;03m# Always execute a new query for a new iterator.\u001b[39;00m\n\u001b[1;32m    111\u001b[0m     \u001b[38;5;66;03m# This could be optimized with a cache at the expense of RAM.\u001b[39;00m\n\u001b[0;32m--> 112\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_execute_query\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    113\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m connections[\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39musing]\u001b[38;5;241m.\u001b[39mfeatures\u001b[38;5;241m.\u001b[39mcan_use_chunked_reads:\n\u001b[1;32m    114\u001b[0m         \u001b[38;5;66;03m# If the database can't use chunked reads we need to make sure we\u001b[39;00m\n\u001b[1;32m    115\u001b[0m         \u001b[38;5;66;03m# evaluate the entire query up front.\u001b[39;00m\n\u001b[1;32m    116\u001b[0m         result \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mlist\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcursor)\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/django/db/models/sql/query.py:152\u001b[0m, in \u001b[0;36mRawQuery._execute_query\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    149\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mRuntimeError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnexpected params type: \u001b[39m\u001b[38;5;132;01m%s\u001b[39;00m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m%\u001b[39m params_type)\n\u001b[1;32m    151\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcursor \u001b[38;5;241m=\u001b[39m connection\u001b[38;5;241m.\u001b[39mcursor()\n\u001b[0;32m--> 152\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcursor\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msql\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mparams\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/django/db/backends/utils.py:102\u001b[0m, in \u001b[0;36mCursorDebugWrapper.execute\u001b[0;34m(self, sql, params)\u001b[0m\n\u001b[1;32m    100\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mexecute\u001b[39m(\u001b[38;5;28mself\u001b[39m, sql, params\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[1;32m    101\u001b[0m     \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdebug_sql(sql, params, use_last_executed_query\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m):\n\u001b[0;32m--> 102\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43msql\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mparams\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/django/db/backends/utils.py:67\u001b[0m, in \u001b[0;36mCursorWrapper.execute\u001b[0;34m(self, sql, params)\u001b[0m\n\u001b[1;32m     66\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mexecute\u001b[39m(\u001b[38;5;28mself\u001b[39m, sql, params\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[0;32m---> 67\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_execute_with_wrappers\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m     68\u001b[0m \u001b[43m        \u001b[49m\u001b[43msql\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mparams\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmany\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mexecutor\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_execute\u001b[49m\n\u001b[1;32m     69\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/django/db/backends/utils.py:80\u001b[0m, in \u001b[0;36mCursorWrapper._execute_with_wrappers\u001b[0;34m(self, sql, params, many, executor)\u001b[0m\n\u001b[1;32m     78\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m wrapper \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mreversed\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdb\u001b[38;5;241m.\u001b[39mexecute_wrappers):\n\u001b[1;32m     79\u001b[0m     executor \u001b[38;5;241m=\u001b[39m functools\u001b[38;5;241m.\u001b[39mpartial(wrapper, executor)\n\u001b[0;32m---> 80\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mexecutor\u001b[49m\u001b[43m(\u001b[49m\u001b[43msql\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mparams\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmany\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcontext\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/django/db/backends/utils.py:84\u001b[0m, in \u001b[0;36mCursorWrapper._execute\u001b[0;34m(self, sql, params, *ignored_wrapper_args)\u001b[0m\n\u001b[1;32m     82\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_execute\u001b[39m(\u001b[38;5;28mself\u001b[39m, sql, params, \u001b[38;5;241m*\u001b[39mignored_wrapper_args):\n\u001b[1;32m     83\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdb\u001b[38;5;241m.\u001b[39mvalidate_no_broken_transaction()\n\u001b[0;32m---> 84\u001b[0m     \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdb\u001b[38;5;241m.\u001b[39mwrap_database_errors:\n\u001b[1;32m     85\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m params \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m     86\u001b[0m             \u001b[38;5;66;03m# params default might be backend specific.\u001b[39;00m\n\u001b[1;32m     87\u001b[0m             \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcursor\u001b[38;5;241m.\u001b[39mexecute(sql)\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/django/db/utils.py:91\u001b[0m, in \u001b[0;36mDatabaseErrorWrapper.__exit__\u001b[0;34m(self, exc_type, exc_value, traceback)\u001b[0m\n\u001b[1;32m     89\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m dj_exc_type \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m (DataError, IntegrityError):\n\u001b[1;32m     90\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mwrapper\u001b[38;5;241m.\u001b[39merrors_occurred \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m\n\u001b[0;32m---> 91\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m dj_exc_value\u001b[38;5;241m.\u001b[39mwith_traceback(traceback) \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mexc_value\u001b[39;00m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/django/db/backends/utils.py:89\u001b[0m, in \u001b[0;36mCursorWrapper._execute\u001b[0;34m(self, sql, params, *ignored_wrapper_args)\u001b[0m\n\u001b[1;32m     87\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcursor\u001b[38;5;241m.\u001b[39mexecute(sql)\n\u001b[1;32m     88\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m---> 89\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcursor\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43msql\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mparams\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[0;31mProgrammingError\u001b[0m: column \"area_score\" does not exist\nLINE 1: SELECT id, rnb_id, area_score + x_score as score, CASE WHEN ...\n                           ^\n"
+     ]
+    }
+   ],
+   "source": [
+    "q = (\n",
+    "    \"SELECT id, rnb_id, area_score + x_score as score, \"\n",
+    "    \"CASE WHEN ST_Area(shape) > 100 THEN 1 ELSE 0 END AS area_score, \"\n",
+    "    \"CASE WHEN rnb_id LIKE 'PEP' THEN 1 ELSE 0 END AS x_score \"\n",
+    "    \"FROM batid_building \"\n",
+    "    \"ORDER BY score DESC \"\n",
+    "    \"LIMIT 10\"\n",
+    ")\n",
+    "\n",
+    "qs = Building.objects.raw(q)\n",
+    "\n",
+    "for b in qs:\n",
+    "    print(b.rnb_id, b.score)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b152001f",
+   "id": "351c45b7",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Pour des raisons de perfs, on sépare l'algo de rapprochement des simples endpoints de listing de bâtiment. Cette PR contient le nouveau mécanisme pour les endpoints de listing et de consultation d'un bâtiment.