### PR TITLE
Pagination sans "count" pour nb total de pages sur API bdg

### DIFF
--- a/app/api_alpha/pagination.py
+++ b/app/api_alpha/pagination.py
@@ -1,0 +1,17 @@
+from collections import OrderedDict
+
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+
+
+class PagedNumberNoCount(PageNumberPagination):
+    def get_paginated_response(self, data):
+        return Response(
+            OrderedDict(
+                [
+                    ("next", self.get_next_link()),
+                    ("previous", self.get_previous_link()),
+                    ("results", data),
+                ]
+            )
+        )


### PR DESCRIPTION
On doit retirer le compte total de résultats (et donc de pages) sur l'API bâtiments. Le compte total est bien trop gourmand.