### PR TITLE
Nettoyage du BuildingSearch

### DIFF
--- a/app/api_alpha/tests/test_buildings.py
+++ b/app/api_alpha/tests/test_buildings.py
@@ -93,7 +93,7 @@ class BuildingsEndpointsTest(APITestCase):
 
     def test_bdg_in_bbox(self):
         r = self.client.get(
-            "/api/alpha/buildings/?bbox=45.18468473541278,5.7211808330356,45.18355043319679,5.722614035153486"
+            "/api/alpha/buildings/?bb=45.18468473541278,5.7211808330356,45.18355043319679,5.722614035153486"
         )
         self.assertEqual(r.status_code, 200)
 

--- a/app/batid/list_bdg.py
+++ b/app/batid/list_bdg.py
@@ -19,7 +19,7 @@ def public_bdg_queryset(user=None) -> QuerySet:
 
 def filter_bdg_queryset(qs: QuerySet, params) -> QuerySet:
     # Bounding box
-    bbox_str = params.get("bbox", None)
+    bbox_str = params.get("bb", None)
     if bbox_str:
         nw_lat, nw_lng, se_lat, se_lng = [float(coord) for coord in bbox_str.split(",")]
         poly_coords = (
@@ -49,6 +49,6 @@ def filter_bdg_queryset(qs: QuerySet, params) -> QuerySet:
         else:
             status = query_status_str.split(",")
 
-    qs = qs.filter(status__type__in=status)
+    qs = qs.filter(status__type__in=status, status__is_current=True)
 
     return qs


### PR DESCRIPTION
Retrait des paramètres de recherche qui sont maintenant dans le queryset renvoyé par public_bdg_queryset et filter_bdg_querysert.

Adaptation des tests en conséquence.

