### PR TITLE
Ajout de Flower 🌼 pour monitorer Celery 

### DIFF
--- a/.env.worker.example
+++ b/.env.worker.example
@@ -3,6 +3,7 @@
 
 CELERY_BROKER_URL=amqp://guest:guest@rabbitmq//
 CELERY_RESULT_BACKEND=redis://redis:6379/0
+FLOWER_PORT=5555
 
 DOWNLOAD_DIR=/data/downloads
 

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -34,6 +34,8 @@ CSRF_TRUSTED_ORIGINS = os.environ.get("DJANGO_CSRF_TRUSTED_ORIGINS").split(" ")
 CORS_ALLOWED_ORIGINS = os.environ.get("DJANGO_CORS_ALLOWED_ORIGINS").split(" ")
 CORS_ALLOW_ALL_ORIGINS = True
 
+LOGIN_URL = "/admin/login/"
+
 
 if DEBUG:
     import socket  # only if you haven't already imported this
@@ -71,6 +73,7 @@ INSTALLED_APPS = [
     "api_alpha",
     "xp",
     "django_extensions",
+    "revproxy",
 ]
 
 MIDDLEWARE = [

--- a/app/app/urls.py
+++ b/app/app/urls.py
@@ -15,10 +15,12 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from batid.views import FlowerProxyView
 
 urlpatterns = [
     path("", include("website.urls")),
     path("api/alpha/", include("api_alpha.urls")),
     path("admin/", admin.site.urls),
+    FlowerProxyView.as_url(),
     path("__debug__/", include("debug_toolbar.urls")),
 ]

--- a/app/batid/views.py
+++ b/app/batid/views.py
@@ -3,6 +3,7 @@ from app.celery import app as celery_app
 from django.contrib.auth.mixins import UserPassesTestMixin
 from revproxy.views import ProxyView
 from django.urls import re_path
+import os
 
 
 def worker(request):
@@ -20,7 +21,7 @@ def worker(request):
 
 class FlowerProxyView(UserPassesTestMixin, ProxyView):
     # `flower` is Docker container, you can use `localhost` instead
-    upstream = "http://flower:5555"
+    upstream = "http://flower:{}/".format(os.environ.get("FLOWER_PORT", "5555"))
     url_prefix = "flower"
     rewrite = ((r"^/{}$".format(url_prefix), r"/{}/".format(url_prefix)),)
 

--- a/app/batid/views.py
+++ b/app/batid/views.py
@@ -21,7 +21,7 @@ def worker(request):
 
 class FlowerProxyView(UserPassesTestMixin, ProxyView):
     # `flower` is Docker container, you can use `localhost` instead
-    upstream = "http://flower:{}/".format(os.environ.get("FLOWER_PORT", "5555"))
+    upstream = "http://flower:{}".format(os.environ.get("FLOWER_PORT", "5555"))
     url_prefix = "flower"
     rewrite = ((r"^/{}$".format(url_prefix), r"/{}/".format(url_prefix)),)
 

--- a/app/batid/views.py
+++ b/app/batid/views.py
@@ -1,11 +1,32 @@
 from django.shortcuts import render
 from app.celery import app as celery_app
+from django.contrib.auth.mixins import UserPassesTestMixin
+from revproxy.views import ProxyView
+from django.urls import re_path
+
 
 def worker(request):
-
     i = celery_app.control.inspect()
     active_tasks = i.active()
 
-    return render(request, 'admin/tasks.html', {
-        'active_tasks': active_tasks,
-    })
+    return render(
+        request,
+        "admin/tasks.html",
+        {
+            "active_tasks": active_tasks,
+        },
+    )
+
+
+class FlowerProxyView(UserPassesTestMixin, ProxyView):
+    # `flower` is Docker container, you can use `localhost` instead
+    upstream = "http://0.0.0.0:{}".format(5555)
+    url_prefix = "flower"
+    rewrite = ((r"^/{}$".format(url_prefix), r"/{}/".format(url_prefix)),)
+
+    def test_func(self):
+        return self.request.user.is_superuser
+
+    @classmethod
+    def as_url(cls):
+        return re_path(r"^(?P<path>{}.*)$".format(cls.url_prefix), cls.as_view())

--- a/app/batid/views.py
+++ b/app/batid/views.py
@@ -20,7 +20,7 @@ def worker(request):
 
 class FlowerProxyView(UserPassesTestMixin, ProxyView):
     # `flower` is Docker container, you can use `localhost` instead
-    upstream = "http://0.0.0.0:{}".format(5555)
+    upstream = "http://flower:5555"
     url_prefix = "flower"
     rewrite = ((r"^/{}$".format(url_prefix), r"/{}/".format(url_prefix)),)
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -138,3 +138,5 @@ webencodings==0.5.1
 websocket-client==1.5.1
 whitenoise==6.4.0
 drf-api-tracking==1.8.4
+flower==2.0.1
+django-revproxy==0.11.0

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -84,9 +84,8 @@ services:
     image: mher/flower
     container_name: flower
     command: celery flower --url_prefix=flower # This will execute flower.
-    environment:
-      - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq//
-      - FLOWER_PORT=5555
+    env_file:
+      - ./.env.worker.prod
     ports:
       - 5555:5555 # docker will expose this ports for flower
 volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -80,6 +80,15 @@ services:
     command: redis-server --appendonly yes --replica-read-only no
     ports:
       - "6379:6379"
+  flower:
+    image: mher/flower
+    container_name: flower
+    command: celery flower --url_prefix=flower # This will execute flower.
+    environment:
+      - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq//
+      - FLOWER_PORT=5555
+    ports:
+      - 5555:5555 # docker will expose this ports for flower
 volumes:
   certs:
   vhost:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,12 @@ version: "3.9"
 services:
   web:
     build:
-        context: .
-        dockerfile: ./app/Dockerfile
-        target: app_web
+      context: .
+      dockerfile: ./app/Dockerfile
+      target: app_web
     ports:
       - '8000:8000'
       - '8888:8888'
-      - '5555:5555'
     env_file:
       - ./.env.db_auth.dev
       - ./.env.app.dev
@@ -17,8 +16,8 @@ services:
       - ./.env.rnb.dev
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
-        - ./app:/app
-        - ./source_data:/data/downloads
+      - ./app:/app
+      - ./source_data:/data/downloads
     depends_on:
       - db
       - rabbitmq
@@ -68,6 +67,15 @@ services:
     command: blackd --bind-host 0.0.0.0 --bind-port 45484
     ports:
       - "45484:45484"
+  flower:
+    image: mher/flower
+    container_name: flower
+    command: celery flower --url_prefix=flower # This will execute flower.
+    environment:
+      - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq//
+      - FLOWER_PORT=5555
+    ports:
+      - 5555:5555 # docker will expose this ports for flower
 volumes:
   postgres_data:
   rabbitmq_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     ports:
       - '8000:8000'
       - '8888:8888'
+      - '5555:5555'
     env_file:
       - ./.env.db_auth.dev
       - ./.env.app.dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,9 +71,8 @@ services:
     image: mher/flower
     container_name: flower
     command: celery flower --url_prefix=flower # This will execute flower.
-    environment:
-      - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq//
-      - FLOWER_PORT=5555
+    env_file:
+      - ./.env.worker.dev
     ports:
       - 5555:5555 # docker will expose this ports for flower
 volumes:


### PR DESCRIPTION
[Flower](https://flower.readthedocs.io/en/latest/) est l'outil officiellement [recommandé](https://docs.celeryq.dev/en/stable/userguide/monitoring.html#flower-real-time-celery-web-monitor) pour monitorer Celery.

Cette PR l'installe et créée une page `/flower` qui nécessite pour être visitée d'être loggé sur le site en tant qu'admin.

J'utilise pour cela le package django-reverse, qui permet de rediriger toutes les requetes qui sont faites sur /flower dans le container web vers le container dédié flower.

Sources utiles:
* https://medium.com/@muhammad-azeem-akhter/integrating-flower-with-celery-in-django-project-using-docker-5ba37a8d7dee
* https://stackoverflow.com/a/75329234/1892308