### PR TITLE
Modification de l'alphabet de génération des identifiants

### DIFF
--- a/app/batid/services/rnb_id.py
+++ b/app/batid/services/rnb_id.py
@@ -2,8 +2,9 @@ from nanoid import generate
 
 
 def generate_rnb_id() -> str:
-    # we remove 0, O and I from alphabet to avoid confusion when reading
-    alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZ"
+    # we remove 0, O, I, L and U from alphabet to avoid confusion when reading
+    # as discussed here : https://github.com/fab-geocommuns/BatID/issues/24#issue-1597255114
+    alphabet = "123456789ABCDEFGHJKMNPQRSTVWXYZ"
     return generate(size=12, alphabet=alphabet)
 
 


### PR DESCRIPTION
L'alphabet disponible pour la génération des identifiants a été indiqué ici : https://github.com/fab-geocommuns/BatID/issues/24#issue-1597255114

L'alphabet qui tournait en production contenait les L et les U alors que ça ne devrait pas être le cas (cf. lien ci-dessus).