### PR TITLE
Améliore la vitesse du endpoint de listing de bâtiments

### DIFF
--- a/app/api_alpha/tests/test_buildings.py
+++ b/app/api_alpha/tests/test_buildings.py
@@ -97,102 +97,114 @@ class BuildingsEndpointsTest(APITestCase):
         )
         self.assertEqual(r.status_code, 200)
 
-        expected = [
-            {
-                "addresses": [],
-                "ext_bdtopo_id": None,
-                "point": {
-                    "coordinates": [5.7211808330356, 45.18433388648706],
-                    "type": "Point",
-                },
-                "rnb_id": "INGRENOBLEGO",
-                "status": [
-                    {
-                        "happened_at": "2023-02-01",
-                        "is_current": True,
-                        "label": "Construit",
-                        "type": "constructed",
-                    }
-                ],
-            }
-        ]
+        expected = {
+            "previous": None,
+            "next": None,
+            "results": [
+                {
+                    "addresses": [],
+                    "ext_bdtopo_id": None,
+                    "point": {
+                        "coordinates": [5.7211808330356, 45.18433388648706],
+                        "type": "Point",
+                    },
+                    "rnb_id": "INGRENOBLEGO",
+                    "status": [
+                        {
+                            "happened_at": "2023-02-01",
+                            "is_current": True,
+                            "label": "Construit",
+                            "type": "constructed",
+                        }
+                    ],
+                }
+            ],
+        }
 
         data = r.json()
 
-        self.assertEqual(len(data), 1)
-        self.assertListEqual(data, expected)
+        self.assertEqual(len(data["results"]), 1)
+        self.assertDictEqual(data, expected)
 
     def test_bdg_in_city(self):
         r = self.client.get("/api/alpha/buildings/?insee_code=38185")
         self.assertEqual(r.status_code, 200)
 
-        expected = [
-            {
-                "addresses": [],
-                "ext_bdtopo_id": None,
-                "point": {
-                    "coordinates": [5.7211808330356, 45.18433388648706],
-                    "type": "Point",
-                },
-                "rnb_id": "INGRENOBLEGO",
-                "status": [
-                    {
-                        "happened_at": "2023-02-01",
-                        "is_current": True,
-                        "label": "Construit",
-                        "type": "constructed",
-                    }
-                ],
-            }
-        ]
+        expected = {
+            "previous": None,
+            "next": None,
+            "results": [
+                {
+                    "addresses": [],
+                    "ext_bdtopo_id": None,
+                    "point": {
+                        "coordinates": [5.7211808330356, 45.18433388648706],
+                        "type": "Point",
+                    },
+                    "rnb_id": "INGRENOBLEGO",
+                    "status": [
+                        {
+                            "happened_at": "2023-02-01",
+                            "is_current": True,
+                            "label": "Construit",
+                            "type": "constructed",
+                        }
+                    ],
+                }
+            ],
+        }
 
         data = r.json()
 
-        self.assertEqual(len(data), 1)
-        self.assertListEqual(data, expected)
+        self.assertEqual(len(data["results"]), 1)
+        self.assertDictEqual(data, expected)
 
     def test_buildings_root(self):
         r = self.client.get("/api/alpha/buildings/")
         self.assertEqual(r.status_code, 200)
 
-        expected = [
-            {
-                "ext_bdtopo_id": None,
-                "rnb_id": "BDGSRNBBIDID",
-                "status": [
-                    {
-                        "type": "constructed",
-                        "label": "Construit",
-                        "happened_at": None,
-                        "is_current": True,
-                    }
-                ],
-                "point": {
-                    "type": "Point",
-                    "coordinates": [1.065566769109709, 46.63416324688213],
+        expected = {
+            "previous": None,
+            "next": None,
+            "results": [
+                {
+                    "ext_bdtopo_id": None,
+                    "rnb_id": "BDGSRNBBIDID",
+                    "status": [
+                        {
+                            "type": "constructed",
+                            "label": "Construit",
+                            "happened_at": None,
+                            "is_current": True,
+                        }
+                    ],
+                    "point": {
+                        "type": "Point",
+                        "coordinates": [1.065566769109709, 46.63416324688213],
+                    },
+                    "addresses": [],
                 },
-                "addresses": [],
-            },
-            {
-                "addresses": [],
-                "ext_bdtopo_id": None,
-                "point": {
-                    "coordinates": [5.7211808330356, 45.18433388648706],
-                    "type": "Point",
+                {
+                    "addresses": [],
+                    "ext_bdtopo_id": None,
+                    "point": {
+                        "coordinates": [5.7211808330356, 45.18433388648706],
+                        "type": "Point",
+                    },
+                    "rnb_id": "INGRENOBLEGO",
+                    "status": [
+                        {
+                            "happened_at": "2023-02-01",
+                            "is_current": True,
+                            "label": "Construit",
+                            "type": "constructed",
+                        }
+                    ],
                 },
-                "rnb_id": "INGRENOBLEGO",
-                "status": [
-                    {
-                        "happened_at": "2023-02-01",
-                        "is_current": True,
-                        "label": "Construit",
-                        "type": "constructed",
-                    }
-                ],
-            },
-        ]
+            ],
+        }
 
-        self.assertListEqual(r.json(), expected)
+        self.assertDictEqual(r.json(), expected)
 
     def test_one_bdg_with_dash(self):
         r = self.client.get("/api/alpha/buildings/BDGS-RNBB-IDID/")
@@ -242,62 +254,66 @@ class BuildingsEndpointsWithAuthTest(BuildingsEndpointsTest):
 
         self.assertEqual(r.status_code, 200)
 
-        expected = [
-            {
-                "ext_bdtopo_id": None,
-                "rnb_id": "BDGPROJ",
-                "point": {
-                    "type": "Point",
-                    "coordinates": [1.065566769109709, 46.63416324688213],
+        expected = {
+            "previous": None,
+            "next": None,
+            "results": [
+                {
+                    "ext_bdtopo_id": None,
+                    "rnb_id": "BDGSRNBBIDID",
+                    "point": {
+                        "type": "Point",
+                        "coordinates": [1.065566769109709, 46.63416324688213],
+                    },
+                    "status": [
+                        {
+                            "type": "constructed",
+                            "label": "Construit",
+                            "happened_at": None,
+                            "is_current": True,
+                        }
+                    ],
+                    "addresses": [],
                 },
-                "status": [
-                    {
-                        "type": "constructionProject",
-                        "label": "En projet",
-                        "is_current": True,
-                        "happened_at": "2020-02-01",
-                    }
-                ],
-                "addresses": [],
-            },
-            {
-                "ext_bdtopo_id": None,
-                "rnb_id": "BDGSRNBBIDID",
-                "point": {
-                    "type": "Point",
-                    "coordinates": [1.065566769109709, 46.63416324688213],
+                {
+                    "ext_bdtopo_id": None,
+                    "rnb_id": "BDGPROJ",
+                    "point": {
+                        "type": "Point",
+                        "coordinates": [1.065566769109709, 46.63416324688213],
+                    },
+                    "status": [
+                        {
+                            "type": "constructionProject",
+                            "label": "En projet",
+                            "is_current": True,
+                            "happened_at": "2020-02-01",
+                        }
+                    ],
+                    "addresses": [],
                 },
-                "status": [
-                    {
-                        "type": "constructed",
-                        "label": "Construit",
-                        "happened_at": None,
-                        "is_current": True,
-                    }
-                ],
-                "addresses": [],
-            },
-            {
-                "addresses": [],
-                "ext_bdtopo_id": None,
-                "point": {
-                    "coordinates": [5.7211808330356, 45.18433388648706],
-                    "type": "Point",
+                {
+                    "addresses": [],
+                    "ext_bdtopo_id": None,
+                    "point": {
+                        "coordinates": [5.7211808330356, 45.18433388648706],
+                        "type": "Point",
+                    },
+                    "rnb_id": "INGRENOBLEGO",
+                    "status": [
+                        {
+                            "happened_at": "2023-02-01",
+                            "is_current": True,
+                            "label": "Construit",
+                            "type": "constructed",
+                        }
+                    ],
                 },
-                "rnb_id": "INGRENOBLEGO",
-                "status": [
-                    {
-                        "happened_at": "2023-02-01",
-                        "is_current": True,
-                        "label": "Construit",
-                        "type": "constructed",
-                    }
-                ],
-            },
-        ]
+            ],
+        }
 
-        self.assertEqual(len(data), 3)
-        self.assertListEqual(data, expected)
+        self.assertEqual(len(data["results"]), 3)
+        self.assertDictEqual(data, expected)
 
 
 class BuildingsEndpointsSingleTest(APITestCase):

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -20,7 +20,7 @@ from batid.models import ADS, Building
 
 from rest_framework import viewsets, status
 from rest_framework.exceptions import ParseError
-from rest_framework.pagination import PageNumberPagination
+from rest_framework.pagination import PageNumberPagination, CursorPagination
 from rest_framework.response import Response
 
 from django.http import HttpResponse, Http404
@@ -45,14 +45,19 @@ class BuildingGuessView(APIView):
         return Response(serializer.data)
 
 
+class BuildingCursorPagination(CursorPagination):
+    page_size = 20
+    ordering = "id"
+
+
 class BuildingViewSet(LoggingMixin, viewsets.ModelViewSet):
     queryset = Building.objects.all()
     serializer_class = BuildingSerializer
     http_method_names = ["get"]
     lookup_field = "rnb_id"
-    page_size = 20
 
-    pagination_class = None
+    pagination_class = BuildingCursorPagination
+    # pagination_class = PageNumberPagination
 
     def get_object(self):
         try:
@@ -67,12 +72,7 @@ class BuildingViewSet(LoggingMixin, viewsets.ModelViewSet):
 
         qs = list_bdgs(query_params)
 
-        # Paginate the queryset
-        page = self.request.query_params.get("page", 1)
-        start = (int(page) - 1) * self.page_size
-        end = start + self.page_size
-
-        return qs[start:end]
+        return qs
 
 
 class ADSBatchViewSet(LoggingMixin, viewsets.ModelViewSet):

--- a/app/batid/list_bdg.py
+++ b/app/batid/list_bdg.py
@@ -51,6 +51,4 @@ def list_bdgs(params):
         city = City.objects.get(code_insee=insee_code)
         qs = qs.filter(shape__intersects=city.shape)
 
-    qs = qs.order_by("rnb_id")
-
     return qs

--- a/app/batid/management/commands/sandbox.py
+++ b/app/batid/management/commands/sandbox.py
@@ -1,15 +1,10 @@
 from django.contrib.gis.geos import Point
 from django.core.management.base import BaseCommand
 from batid.list_bdg import list_bdgs
+from batid.services.building import add_default_status
 from batid.services.guess_bdg import BuildingGuess
 
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        qs = list_bdgs(
-            {
-                "insee_code": "33063",
-            }
-        )
-
-        print(qs.query)
+        add_default_status()

--- a/app/batid/tasks.py
+++ b/app/batid/tasks.py
@@ -133,12 +133,13 @@ def add_default_status():
     print("---- Adding default status ----")
 
     added = 0
+    after_id = 0
 
     while True:
-        c = add_default_status_job()
-        added += c
+        count, after_id = add_default_status_job(after_id)
+        added += count
         print(f"Added {added} default status so far")
-        if c <= 0:
+        if count <= 0:
             break
 
     return "done"


### PR DESCRIPTION
Nous avons constaté que le endpoint de listing des bâtiment était lent, en particulier sur les requêtes filtrant les bâtiment par ville. Par exemple :

```
https://rnb-api.beta.gouv.fr/api/alpha/buildings/?insee_code=33422
```

Cela était dû à deux raisons qui se combinaient : 
- une requête très mal écrite avec notamment une double jointure vers une même table
- un système de pagination (LIMIT et OFFSET) s'accomodant très mal de filtre géographique sur une table de 40M d'enregistrements


Pour remédier à cela, nous avons : 
- nettoyé la requête initiale
- modifié le système de pagination pour adopter une pagination par curseur (cf [documentation de Django Rest Framework à ce sujet](https://www.django-rest-framework.org/api-guide/pagination/#cursorpagination)).
