### PR TITLE
Eviter enregistrement des appels à l'url quand issus du monitoring

### DIFF
--- a/app/api_alpha/tests/test_log.py
+++ b/app/api_alpha/tests/test_log.py
@@ -40,21 +40,3 @@ class LogEndpointsTest(APITestCase):
         count = APIRequestLog.objects.all().count()
 
         self.assertEqual(count, 0)
-
-    def test_tiles_log(self):
-        r = self.client.get("/api/alpha/tiles/130662/94493/18.pbf")
-
-        self.assertEqual(r.status_code, 200)
-
-        count = APIRequestLog.objects.all().count()
-
-        self.assertEqual(count, 1)
-
-    def test_tiles_no_log(self):
-        r = self.client.get("/api/alpha/tiles/130662/94493/18.pbf?from=monitoring")
-
-        self.assertEqual(r.status_code, 200)
-
-        count = APIRequestLog.objects.all().count()
-
-        self.assertEqual(count, 0)

--- a/app/api_alpha/tests/test_log.py
+++ b/app/api_alpha/tests/test_log.py
@@ -1,0 +1,60 @@
+from rest_framework.test import APITestCase
+from rest_framework_tracking.models import APIRequestLog
+
+
+class LogEndpointsTest(APITestCase):
+    def test_list_log(self):
+        r = self.client.get("/api/alpha/buildings/")
+
+        self.assertEqual(r.status_code, 200)
+
+        count = APIRequestLog.objects.all().count()
+
+        self.assertEqual(count, 1)
+
+    def test_list_no_log(self):
+        r = self.client.get("/api/alpha/buildings/?from=monitoring")
+
+        self.assertEqual(r.status_code, 200)
+
+        count = APIRequestLog.objects.all().count()
+
+        self.assertEqual(count, 0)
+
+    def test_guess_log(self):
+        r = self.client.get("/api/alpha/buildings/guess/?address=whatever")
+
+        self.assertEqual(r.status_code, 200)
+
+        count = APIRequestLog.objects.all().count()
+
+        self.assertEqual(count, 1)
+
+    def test_guess_no_log(self):
+        r = self.client.get(
+            "/api/alpha/buildings/guess/?address=whatever&from=monitoring"
+        )
+
+        self.assertEqual(r.status_code, 200)
+
+        count = APIRequestLog.objects.all().count()
+
+        self.assertEqual(count, 0)
+
+    def test_tiles_log(self):
+        r = self.client.get("/api/alpha/tiles/130662/94493/18.pbf")
+
+        self.assertEqual(r.status_code, 200)
+
+        count = APIRequestLog.objects.all().count()
+
+        self.assertEqual(count, 1)
+
+    def test_tiles_no_log(self):
+        r = self.client.get("/api/alpha/tiles/130662/94493/18.pbf?from=monitoring")
+
+        self.assertEqual(r.status_code, 200)
+
+        count = APIRequestLog.objects.all().count()
+
+        self.assertEqual(count, 0)

--- a/app/api_alpha/urls.py
+++ b/app/api_alpha/urls.py
@@ -3,7 +3,7 @@ from api_alpha.views import (
     ADSBatchViewSet,
     BuildingViewSet,
     BuildingGuessView,
-    BuildingTilesView,
+    get_tile,
 )
 from django.urls import include, path
 from rest_framework import routers
@@ -22,6 +22,6 @@ urlpatterns = [
     path("buildings/guess/", BuildingGuessView.as_view()),
     path("", include(router.urls)),
     path("login/", auth_views.obtain_auth_token),
-    path("tiles/<int:x>/<int:y>/<int:z>.pbf", BuildingTilesView.as_view())
+    path("tiles/<int:x>/<int:y>/<int:z>.pbf", get_tile)
     # path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]

--- a/app/api_alpha/urls.py
+++ b/app/api_alpha/urls.py
@@ -2,8 +2,8 @@ from api_alpha.views import (
     ADSViewSet,
     ADSBatchViewSet,
     BuildingViewSet,
-    get_tile,
     BuildingGuessView,
+    BuildingTilesView,
 )
 from django.urls import include, path
 from rest_framework import routers
@@ -22,6 +22,6 @@ urlpatterns = [
     path("buildings/guess/", BuildingGuessView.as_view()),
     path("", include(router.urls)),
     path("login/", auth_views.obtain_auth_token),
-    path("tiles/<int:x>/<int:y>/<int:z>.pbf", get_tile)
+    path("tiles/<int:x>/<int:y>/<int:z>.pbf", BuildingTilesView.as_view())
     # path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -28,7 +28,15 @@ from batid.services.vector_tiles import tile_sql, url_params_to_tile
 from rest_framework_tracking.mixins import LoggingMixin
 
 
-class BuildingGuessView(APIView):
+class RNBLoggingMixin(LoggingMixin):
+    def should_log(self, request, response):
+        if request.query_params.get("from") == "monitoring":
+            return False
+
+        return True
+
+
+class BuildingGuessView(RNBLoggingMixin, APIView):
     def get(self, request, *args, **kwargs):
         search = BuildingGuess()
         search.set_params_from_url(**request.query_params.dict())
@@ -50,7 +58,7 @@ class BuildingCursorPagination(CursorPagination):
     ordering = "id"
 
 
-class BuildingViewSet(LoggingMixin, viewsets.ModelViewSet):
+class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
     queryset = Building.objects.all()
     serializer_class = BuildingSerializer
     http_method_names = ["get"]
@@ -75,7 +83,7 @@ class BuildingViewSet(LoggingMixin, viewsets.ModelViewSet):
         return qs
 
 
-class ADSBatchViewSet(LoggingMixin, viewsets.ModelViewSet):
+class ADSBatchViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
     queryset = ADS.objects.all()
     serializer_class = ADSSerializer
     lookup_field = "file_number"
@@ -126,7 +134,7 @@ class ADSBatchViewSet(LoggingMixin, viewsets.ModelViewSet):
             raise ParseError({"errors": "No data in the request."})
 
 
-class ADSViewSet(LoggingMixin, viewsets.ModelViewSet):
+class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
     queryset = ADS.objects.all()
     serializer_class = ADSSerializer
     lookup_field = "file_number"
@@ -158,12 +166,15 @@ class ADSViewSet(LoggingMixin, viewsets.ModelViewSet):
         return super().retrieve(request, file_number)
 
 
-def get_tile(request, x, y, z):
-    tile_dict = url_params_to_tile(x, y, z)
-    sql = tile_sql(tile_dict)
+class BuildingTilesView(RNBLoggingMixin, APIView):
+    def get(self, request, x, y, z):
+        tile_dict = url_params_to_tile(x, y, z)
+        sql = tile_sql(tile_dict)
 
-    with connection.cursor() as cursor:
-        cursor.execute(sql)
-        tile_file = cursor.fetchone()[0]
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+            tile_file = cursor.fetchone()[0]
 
-    return HttpResponse(tile_file, content_type="application/vnd.mapbox-vector-tile")
+        return HttpResponse(
+            tile_file, content_type="application/vnd.mapbox-vector-tile"
+        )

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -30,10 +30,7 @@ from rest_framework_tracking.mixins import LoggingMixin
 
 class RNBLoggingMixin(LoggingMixin):
     def should_log(self, request, response):
-        if request.query_params.get("from") == "monitoring":
-            return False
-
-        return True
+        return request.query_params.get("from") != "monitoring"
 
 
 class BuildingGuessView(RNBLoggingMixin, APIView):

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -166,15 +166,12 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
         return super().retrieve(request, file_number)
 
 
-class BuildingTilesView(RNBLoggingMixin, APIView):
-    def get(self, request, x, y, z):
-        tile_dict = url_params_to_tile(x, y, z)
-        sql = tile_sql(tile_dict)
+def get_tile(request, x, y, z):
+    tile_dict = url_params_to_tile(x, y, z)
+    sql = tile_sql(tile_dict)
 
-        with connection.cursor() as cursor:
-            cursor.execute(sql)
-            tile_file = cursor.fetchone()[0]
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+        tile_file = cursor.fetchone()[0]
 
-        return HttpResponse(
-            tile_file, content_type="application/vnd.mapbox-vector-tile"
-        )
+    return HttpResponse(tile_file, content_type="application/vnd.mapbox-vector-tile")


### PR DESCRIPTION
Suite à la mise en place d'Uptime Robot, nous avons faussé nos stats de consultation de nos endpoints.

On ajoute une simple règle faisant que les urls ayant un paramètre from=monitoring ne sont pas prises en comptes dans les logs.