### PR TITLE
Gunicorn performance configuration

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       - ./.env.rnb.prod
       - ./.env.worker.prod
       - ./.env.sentry.prod
-    command: gunicorn app.wsgi:application --bind 0.0.0.0:8000
+    command: gunicorn app.wsgi:application --bind 0.0.0.0:8000 --threads 6 --workers 6
     volumes:
       - ./app:/app
       - ./source_data:/home/app/source_data

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -13,7 +13,7 @@ services:
       - ./.env.rnb.staging
       - ./.env.worker.staging
       - ./.env.sentry.staging
-    command: gunicorn app.wsgi:application --bind 0.0.0.0:8000
+    command: gunicorn app.wsgi:application --bind 0.0.0.0:8000 --threads 6 --workers 6
     volumes:
       - ./app:/app
       - ./source_data:/home/app/source_data


### PR DESCRIPTION
Après avoir constaté régulièrement que les performances de la carto publique pouvaient être mauvaises, nous avons investigué et il s'avère que gunicorn n'était configuré que pour gérer une seule requête à la fois. 
Le passage à 6 workers et 6 threads augmente drastiquement les performances et règle le problème de la carto.