### PR TITLE
allow worker concurrency

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -56,7 +56,7 @@ services:
       context: .
       dockerfile: ./app/Dockerfile
       target: app_worker
-    command: celery -A app worker --concurrency=1 --loglevel=INFO
+    command: celery -A app worker --concurrency=4 --loglevel=INFO --pool=threads
     volumes:
       - ./app:/app
       - ./source_data:/data/downloads


### PR DESCRIPTION
Je passe la concurrency de celery à 4 sur staging et je passe le mode en thread, car nos taches sont plus IO bound que CPU bound (c'est la base qui fait le gros du travail, plus que le worker)