### PR TITLE
le retour de bulk_launch_uuid

### DIFF
--- a/app/batid/management/commands/import_bdnb_dpt.py
+++ b/app/batid/management/commands/import_bdnb_dpt.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
         chain(*tasks)()
 
 
-def create_tasks_list(dpt):
+def create_tasks_list(dpt, bulk_launch_uuid=None):
     bdnb_dpt = dpt.lower()
     tasks = []
     tasks.append(
@@ -29,7 +29,7 @@ def create_tasks_list(dpt):
     tasks.append(
         Signature(
             "batid.tasks.import_bdnb7_bdgs",
-            args=[bdnb_dpt],
+            args=[bdnb_dpt, bulk_launch_uuid],
             immutable=True,
         )
     )

--- a/app/batid/management/commands/import_bdtopo_dpt.py
+++ b/app/batid/management/commands/import_bdtopo_dpt.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
         chain(*tasks)()
 
 
-def create_tasks_list(dpt):
+def create_tasks_list(dpt, bulk_launch_uuid=None):
     bdtopo_dpt = dpt.zfill(3)
     tasks = []
     tasks.append(
@@ -23,7 +23,7 @@ def create_tasks_list(dpt):
     tasks.append(
         Signature(
             "batid.tasks.import_bdtopo",
-            args=[bdtopo_dpt],
+            args=[bdtopo_dpt, bulk_launch_uuid],
             immutable=True,
         )
     )

--- a/app/batid/management/commands/import_france.py
+++ b/app/batid/management/commands/import_france.py
@@ -52,9 +52,13 @@ def create_tasks_list_france(start_dpt, end_dpt, task_name):
     start_dpt_index = dpts.index(start_dpt) if start_dpt in dpts else 0
     end_dpt_index = dpts.index(end_dpt) + 1 if start_dpt in dpts else len(dpts)
     create_task_method = task_method(task_name)
+    bulk_launch_uuid = uuid.uuid4()
 
     for dpt in dpts[start_dpt_index:end_dpt_index]:
-        tasks.append(create_task_method(dpt))
+        if task_name in ["bdnb", "bdtopo"]:
+            tasks.append(create_task_method(dpt, bulk_launch_uuid))
+        else:
+            tasks.append(create_task_method(dpt))
     # flattern the list
     tasks = [item for sublist in tasks for item in sublist]
     return tasks

--- a/app/batid/services/imports/building_import_history.py
+++ b/app/batid/services/imports/building_import_history.py
@@ -2,10 +2,10 @@ import uuid
 from batid.models import BuildingImport
 
 
-def insert_building_import(source, dpt) -> BuildingImport:
+def insert_building_import(source, bulk_launch_uuid, dpt) -> BuildingImport:
     building_import = BuildingImport.objects.create(
         import_source=source,
-        bulk_launch_uuid=uuid.uuid4(),
+        bulk_launch_uuid=bulk_launch_uuid or uuid.uuid4(),
         departement=dpt,
         candidate_created_count=0,
         building_created_count=0,

--- a/app/batid/services/imports/import_bdnb7.py
+++ b/app/batid/services/imports/import_bdnb7.py
@@ -13,17 +13,18 @@ from datetime import datetime, timezone
 from django.contrib.gis.geos import GEOSGeometry
 
 from batid.utils.db import list_to_pgarray
-import uuid
 import json
 
 
-def import_bdnb7_bdgs(dpt):
+def import_bdnb7_bdgs(dpt, bulk_launch_uuid=None):
     print(f"## Import BDNB 7 buildings in dpt {dpt}")
 
     source_id = "bdnb_7"
 
     # insert a record in the table BuildingImport
-    building_import = building_import_history.insert_building_import(source_id, dpt)
+    building_import = building_import_history.insert_building_import(
+        source_id, bulk_launch_uuid, dpt
+    )
 
     src = Source(source_id)
     src.set_param("dpt", dpt)

--- a/app/batid/services/imports/import_bdtopo.py
+++ b/app/batid/services/imports/import_bdtopo.py
@@ -14,12 +14,14 @@ import psycopg2
 from django.db import connection, transaction
 
 
-def import_bdtopo(dpt):
+def import_bdtopo(dpt, bulk_launch_uuid=None):
     dpt = dpt.zfill(3)
 
     source_id = "bdtopo"
 
-    building_import = building_import_history.insert_building_import(source_id, dpt)
+    building_import = building_import_history.insert_building_import(
+        source_id, bulk_launch_uuid, dpt
+    )
 
     src = Source(source_id)
     src.set_param("dpt", dpt)

--- a/app/batid/tasks.py
+++ b/app/batid/tasks.py
@@ -51,14 +51,14 @@ def import_bdnb7_addresses(dpt):
 
 
 @shared_task(autoretry_for=(Exception,), retry_kwargs={"max_retries": 3})
-def import_bdnb7_bdgs(dpt):
-    import_bdnb7_bdgs_job(dpt)
+def import_bdnb7_bdgs(dpt, bulk_launch_uuid=None):
+    import_bdnb7_bdgs_job(dpt, bulk_launch_uuid)
     return "done"
 
 
 @shared_task(autoretry_for=(Exception,), retry_kwargs={"max_retries": 3})
-def import_bdtopo(dpt):
-    import_bdtopo_job(dpt)
+def import_bdtopo(dpt, bulk_launch_uuid=None):
+    import_bdtopo_job(dpt, bulk_launch_uuid)
     return "done"
 
 

--- a/app/batid/tests/test_import_france.py
+++ b/app/batid/tests/test_import_france.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from django.test import TestCase
 from batid.management.commands.import_france import create_tasks_list_france, dpts_list
 
@@ -35,3 +36,8 @@ class ImportFranceTestCase(TestCase):
         # there are 3 tasks per departement : dl_source and import_addresses and import_bdgs
         tasks = create_tasks_list_france("01", "95", "bdnb")
         self.assertEqual(len(tasks), len(dpts_list()) * 3)
+
+        import_buildings_tasks_uuid = [t.args[1] for t in tasks if t.name == 'batid.tasks.import_bdnb7_bdgs']
+        counter = Counter(import_buildings_tasks_uuid)
+        # A unique UUID is created for all the tasks coming from the same import_france command
+        self.assertEqual(counter.len(), 1)

--- a/app/batid/tests/test_import_france.py
+++ b/app/batid/tests/test_import_france.py
@@ -40,4 +40,4 @@ class ImportFranceTestCase(TestCase):
         import_buildings_tasks_uuid = [t.args[1] for t in tasks if t.name == 'batid.tasks.import_bdnb7_bdgs']
         counter = Counter(import_buildings_tasks_uuid)
         # A unique UUID is created for all the tasks coming from the same import_france command
-        self.assertEqual(counter.len(), 1)
+        self.assertEqual(len(counter), 1)


### PR DESCRIPTION
J'avais pas bien expliqué le but de ce champ :  permettre de savoir que plusieurs imports viennent de la même commande (typiquement un import france qui génère plusieurs imports départementaux). Je remets le code comme avant et je rajoute des tests sur cet aspect là.