### PR TITLE
Améliorations de la perf

### DIFF
--- a/app/batid/services/candidate.py
+++ b/app/batid/services/candidate.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.contrib.gis.geos import GEOSGeometry
 from django.db import transaction, connection
 from django.db.models import Q
-from shapely.geometry import shape
 from batid.services.bdg_status import BuildingStatus as BuildingStatusService
 from batid.models import Candidate, Building
 from batid.services.rnb_id import generate_rnb_id
@@ -39,7 +38,7 @@ class Inspector:
         self.matching_bdgs = []
 
     def get_candidate(self):
-        q = f"SELECT id, ST_AsEWKB(shape) as shape, source, source_version, source_id, address_keys, is_light, inspected_at  FROM {Candidate._meta.db_table} WHERE inspected_at IS NULL LIMIT 1 FOR UPDATE SKIP LOCKED"
+        q = f"SELECT id, ST_AsEWKB(shape) as shape, source, source_version, source_id, address_keys, is_light, inspected_at  FROM {Candidate._meta.db_table} WHERE inspected_at IS NULL ORDER BY inspected_at ASC LIMIT 1 FOR UPDATE SKIP LOCKED"
         qs = Candidate.objects.raw(q)
         self.candidate = qs[0] if len(qs) > 0 else None
 

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -56,7 +56,7 @@ services:
       context: .
       dockerfile: ./app/Dockerfile
       target: app_worker
-    command: celery -A app worker --concurrency=12 --loglevel=INFO --pool=threads
+    command: celery -A app worker --concurrency=6 --loglevel=INFO
     volumes:
       - ./app:/app
       - ./source_data:/data/downloads
@@ -70,7 +70,25 @@ services:
       - rabbitmq
       - redis
     container_name: worker
-
+  worker_2:
+    build:
+      context: .
+      dockerfile: ./app/Dockerfile
+      target: app_worker
+    command: celery -A app worker --concurrency=6 --loglevel=INFO
+    volumes:
+      - ./app:/app
+      - ./source_data:/data/downloads
+    env_file:
+      - ./.env.db_auth.staging
+      - ./.env.app.staging
+      - ./.env.worker.staging
+      - ./.env.rnb.staging
+      - ./.env.sentry.staging
+    depends_on:
+      - rabbitmq
+      - redis
+    container_name: worker_2
   rabbitmq:
     image: rabbitmq:3.9-alpine
     volumes:


### PR DESCRIPTION
2 améliorations de perf pour l'inspecteur :
 - la requête du select for update était étrangement lente (150ms) pour récupérer une ligne. De manière encore plus étonnante, rajouter un order by rend la requete rapide (~20/30ms). Merci à [SO](https://stackoverflow.com/a/27237698/1892308).
 - j'ai lu cet [article](https://celery.school/celery-worker-pools) à propos de Celery. J'ai testé une conf avec 2 workers de 6 threads chacun en prefork et je suis passé à ~250 buildings insérés par seconde, alors qu'initialement on plafonnait plutôt aux alentours de 20/30. Bon comme le nom l'indique Celery, ça a l'air d'être un peu de la cuisine, mais cette recette a l'air de fonctionner, donc c'est cool.