### PR TITLE
Mise en ordre random lors de l'import

### DIFF
--- a/app/batid/services/candidate.py
+++ b/app/batid/services/candidate.py
@@ -38,7 +38,7 @@ class Inspector:
         self.matching_bdgs = []
 
     def get_candidate(self):
-        q = f"SELECT id, ST_AsEWKB(shape) as shape, source, source_version, source_id, address_keys, is_light, inspected_at  FROM {Candidate._meta.db_table} WHERE inspected_at IS NULL ORDER BY random asc LIMIT 1 FOR UPDATE SKIP LOCKED"
+        q = f"SELECT id, ST_AsEWKB(shape) as shape, source, source_version, source_id, address_keys, is_light, inspected_at  FROM {Candidate._meta.db_table} WHERE inspected_at IS NULL LIMIT 1 FOR UPDATE SKIP LOCKED"
         qs = Candidate.objects.raw(q)
         self.candidate = qs[0] if len(qs) > 0 else None
 

--- a/app/batid/services/imports/import_bdnb_2023_01.py
+++ b/app/batid/services/imports/import_bdnb_2023_01.py
@@ -61,6 +61,8 @@ def import_bdnd_2023_01_bdgs(dpt, bulk_launch_uuid=None):
             }
             candidates.append(candidate)
 
+        candidates = sorted(candidates, key=lambda k: k["random"])
+
         buffer = BufferToCopy()
         print(f"- write buffer to {buffer.path}")
         buffer.write_data(candidates)


### PR DESCRIPTION
On a vu que l'utilisation du random dans l'inspecteur du candidat ralentissait le SELECT. Pour autant, on veut éviter que deux bâtiments qui se superposent et qui auraient été enregistrés à la suite au sein de la bdnb ne soient inspectés en même temps par deux inspecteurs.

On les place en ordre random au moment du passage de la BDNB à Candidat.