### PR TITLE
Tentative d'accélération

### DIFF
--- a/app/batid/services/candidate.py
+++ b/app/batid/services/candidate.py
@@ -38,7 +38,7 @@ class Inspector:
         self.matching_bdgs = []
 
     def get_candidate(self):
-        q = f"SELECT id, ST_AsEWKB(shape) as shape, source, source_version, source_id, address_keys, is_light, inspected_at  FROM {Candidate._meta.db_table} WHERE inspected_at IS NULL ORDER BY random asc LIMIT 1 FOR UPDATE SKIP LOCKED"
+        q = f"SELECT id, ST_AsEWKB(shape) as shape, source, source_version, source_id, address_keys, is_light, inspected_at  FROM {Candidate._meta.db_table} WHERE inspected_at IS NULL ORDER BY random asc, inspected_at as LIMIT 1 FOR UPDATE SKIP LOCKED"
         qs = Candidate.objects.raw(q)
         self.candidate = qs[0] if len(qs) > 0 else None
 

--- a/app/batid/services/candidate.py
+++ b/app/batid/services/candidate.py
@@ -38,7 +38,7 @@ class Inspector:
         self.matching_bdgs = []
 
     def get_candidate(self):
-        q = f"SELECT id, ST_AsEWKB(shape) as shape, source, source_version, source_id, address_keys, is_light, inspected_at  FROM {Candidate._meta.db_table} WHERE inspected_at IS NULL ORDER BY random asc, inspected_at as LIMIT 1 FOR UPDATE SKIP LOCKED"
+        q = f"SELECT id, ST_AsEWKB(shape) as shape, source, source_version, source_id, address_keys, is_light, inspected_at  FROM {Candidate._meta.db_table} WHERE inspected_at IS NULL ORDER BY random asc, inspected_at asc LIMIT 1 FOR UPDATE SKIP LOCKED"
         qs = Candidate.objects.raw(q)
         self.candidate = qs[0] if len(qs) > 0 else None
 


### PR DESCRIPTION
Sur la base d'import, la requete passe à ~50ms en rajoutant le inspected_at dans le order by.

<img width="1202" alt="Capture d’écran 2023-12-08 à 10 04 25" src="https://github.com/fab-geocommuns/RNB-coeur/assets/15341118/10139c00-b67c-41b8-a161-1ee90b000dda">


