### PR TITLE
Score absolu et sous score dans rapprochement

### DIFF
--- a/app/api_alpha/serializers.py
+++ b/app/api_alpha/serializers.py
@@ -64,6 +64,7 @@ class BuildingSerializer(serializers.ModelSerializer):
 
 class GuessBuildingSerializer(serializers.ModelSerializer):
     score = serializers.FloatField(read_only=True)
+    sub_scores = serializers.JSONField(read_only=True)
     point = serializers.DictField(source="point_geojson", read_only=True)
     addresses = AddressSerializer(many=True, read_only=True)
     status = BuildingStatusSerializer(read_only=True, many=True)
@@ -71,7 +72,15 @@ class GuessBuildingSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Building
-        fields = ["rnb_id", "score", "status", "point", "addresses", "ext_ids"]
+        fields = [
+            "rnb_id",
+            "score",
+            "sub_scores",
+            "status",
+            "point",
+            "addresses",
+            "ext_ids",
+        ]
 
 
 class CityADSSerializer(serializers.ModelSerializer):

--- a/app/api_alpha/tests/test_bdg_guess.py
+++ b/app/api_alpha/tests/test_bdg_guess.py
@@ -32,7 +32,8 @@ class BdgGuessEndpointTest(APITestCase):
         expected = [
             {
                 "addresses": [],
-                "score": 1.0,
+                "score": 5.0,
+                "sub_scores": {"point_distance": 5, "point_plot_cluster": 0},
                 "ext_ids": None,
                 "point": {
                     "coordinates": [5.721181338205954, 45.18433384981944],

--- a/app/batid/services/guess_bdg.py
+++ b/app/batid/services/guess_bdg.py
@@ -204,10 +204,15 @@ class BuildingGuess:
 
         # SCORE SUM
         scores_sum = ", 0 as score"
+        subscores_obj = " "
         if len(self.scores):
+            # Total score
             subscore_sum_str = " + ".join(self.scores.keys())
+            scores_sum = f", {subscore_sum_str} as score "
 
-            scores_sum = f", ({subscore_sum_str}) / (sum({subscore_sum_str}) over()) as score, {subscore_sum_str} as abs_score "
+            # Subscores
+            subscores_struct = ", ".join([f"'{k}', {k}" for k in self.scores.keys()])
+            subscores_obj = f", jsonb_build_object({subscores_struct}) as sub_scores "
 
         # ######################
         # Assembling the queries
@@ -220,7 +225,7 @@ class BuildingGuess:
 
         global_query = (
             f"WITH scored_bdgs AS ({score_query}) "
-            f"SELECT *  {scores_sum} "
+            f"SELECT *  {scores_sum} {subscores_obj} "
             f"FROM scored_bdgs "
             "ORDER BY score DESC "
             f"{pagination_str}"

--- a/app/batid/services/guess_bdg.py
+++ b/app/batid/services/guess_bdg.py
@@ -212,7 +212,7 @@ class BuildingGuess:
 
             # Subscores
             subscores_struct = ", ".join([f"'{k}', {k}" for k in self.scores.keys()])
-            subscores_obj = f", jsonb_build_object({subscores_struct}) as sub_scores "
+            subscores_obj = f", json_build_object({subscores_struct}) as sub_scores "
 
         # ######################
         # Assembling the queries


### PR DESCRIPTION
L'utilisation d'un score relatif n'était pas facile à manipuler. On repasse à un score absolu. Aussi, on affiche les sous-scores pour plus facilement comprendre comment est construit ce score.