### PR TITLE
Pas de celery beat en local

### DIFF
--- a/app/batid/services/s3_backup/backup_task.py
+++ b/app/batid/services/s3_backup/backup_task.py
@@ -8,23 +8,23 @@ import time
 
 
 # main function to be called by the cron job
-def backup_to_s3():
+def backup_to_s3(task_id=None):
     try:
         (backup_id, backup_name) = create_scaleway_db_backup()
         download_url = create_backup_download_url(backup_id)
         upload_to_s3(backup_name, download_url)
         notify_mattermost(backup_name)
     except Exception as e:
-        notify_mattermost_error(e)
+        notify_mattermost_error(e, task_id)
         raise e
 
 
-def notify_mattermost_error(error):
+def notify_mattermost_error(error, task_id):
     MATTERMOST_RNB_TECH_WEBHOOK_URL = os.environ.get("MATTERMOST_RNB_TECH_WEBHOOK_URL")
 
     data = {
         "username": "backup-bot",
-        "text": f"Une erreur est survenue lors de la création d'un backup de la base de production du RNB : {error}",
+        "text": f"Une erreur est survenue lors de la création d'un backup de la base de production du RNB : {error}. Task ID : {task_id}",
     }
 
     r = requests.post(MATTERMOST_RNB_TECH_WEBHOOK_URL, data=json.dumps(data))

--- a/app/batid/tasks.py
+++ b/app/batid/tasks.py
@@ -142,8 +142,8 @@ def dispatch_signal(pk: int):
     return "done"
 
 
-@shared_task(autoretry_for=(Exception,), retry_kwargs={"max_retries": 1})
-def backup_to_s3():
+@shared_task(bind=True, autoretry_for=(Exception,), retry_kwargs={"max_retries": 1})
+def backup_to_s3(self):
     # Backing up the database on a separate S3 service
-    backup_to_s3_job()
+    backup_to_s3_job(task_id=self.request.id)
     return "done"

--- a/app/batid/tests/test_s3_backups.py
+++ b/app/batid/tests/test_s3_backups.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+from batid.tasks import backup_to_s3
+from unittest.mock import patch
+import json
+
+
+class TestS3Backups(TestCase):
+    @patch("batid.services.s3_backup.backup_task.requests.post")
+    @patch("celery.app.task.Task.request")
+    def test_s3_backups_error_msg(self, task_id_mock, post_mock):
+        # we simulate an error during the backup creation
+        post_mock.return_value.status_code = 500
+        task_id_mock.id = "some-task_id"
+
+        # assert the exception message
+        with self.assertRaises(Exception) as e:
+            backup_to_s3()
+            self.assertEqual(str(e.exception), "Error while creating the scaleway backup")
+            
+        
+        # assert the mock was called twice (once for the backup creation and once for the mattermost notification)
+        self.assertEqual(post_mock.call_count, 2)
+
+        # get the data sent to mattermost
+        data = json.loads(post_mock.call_args[1]["data"])
+        self.assertEqual(data["username"], "backup-bot")
+        self.assertEqual(data["text"], "Une erreur est survenue lors de la création d'un backup de la base de production du RNB : Error while creating the scaleway backup. Task ID : some-task_id")
+        

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,24 +52,6 @@ services:
       - rabbitmq
     restart: unless-stopped
     container_name: worker
-  celery_beat:
-    build:
-      context: .
-      dockerfile: ./app/Dockerfile
-      target: app_worker
-    command: watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- celery -A app beat --loglevel=INFO
-    env_file:
-      - ./.env.db_auth.dev
-      - ./.env.app.dev
-      - ./.env.worker.dev
-      - ./.env.rnb.dev
-    volumes:
-      - ./app:/app
-    depends_on:
-      - redis
-      - rabbitmq
-    restart: unless-stopped
-    container_name: celery_beat
   rabbitmq:
     restart: unless-stopped
     image: rabbitmq:3.9-alpine


### PR DESCRIPTION
Je pense que les messages d'erreur que nous recevons lors des backups scaleway ne viennent pas de la prod, mais d'une autre instance de l'app qui tourne _quelque part_. Ca n'a pas l'air d'être les instances de staging ou sandbox. Peut-être que ça vient de mon ordi, j'avais un service beat qui tournait dessus, je ne sais pas s'il est capable de lancer des tasks alors que l'ordi est en veille ?

En tout cas je supprime le service celery_beat du docker compose local et je rajoute la task id dans le message mattermost lorsque le backup a échoué, ce qui nous permettra d'identifier à coup sûr qui a envoyé la notification d'erreur si on continue d'en recevoir.

<img width="735" alt="Capture d’écran 2024-02-27 à 15 08 45" src="https://github.com/fab-geocommuns/RNB-coeur/assets/15341118/a722711d-3b3e-4c7c-b4ca-100f8f35395d">
