### PR TITLE
Réparation des webhooks

### DIFF
--- a/app/webhook/tests.py
+++ b/app/webhook/tests.py
@@ -2,11 +2,16 @@ from django.test import TestCase
 from unittest.mock import Mock, patch
 import os
 
+
 # test the webhook view
 class WebhookTestCase(TestCase):
     def setUp(self):
         self.env = patch.dict(
-            "os.environ", {"SCALEWAY_WEBHOOK_TOKEN": "secret_token_xyz", "MATTERMOST_RNB_TECH_WEBHOOK_URL": "https://mattermost.example.com"}
+            "os.environ",
+            {
+                "SCALEWAY_WEBHOOK_TOKEN": "secret_token_xyz",
+                "MATTERMOST_RNB_TECH_WEBHOOK_URL": "https://mattermost.example.com",
+            },
         )
 
     @patch("webhook.views.requests")
@@ -16,36 +21,47 @@ class WebhookTestCase(TestCase):
             mock_response.status_code = 200
             mock_response.content = b"ok"
             mock_requests.post.return_value = mock_response
-            
+
             invoice_start_date = "01-01-2024"
             threshold = 75
 
-            response = self.client.post("/webhook/scaleway/secret_token_xyz", {"invoice_start_date": invoice_start_date, "threshold": threshold})
+            response = self.client.post(
+                "/webhook/scaleway/secret_token_xyz",
+                {"invoice_start_date": invoice_start_date, "threshold": threshold},
+            )
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.content, b"ok")
 
             mock_requests.post.assert_called_once_with(
                 os.environ.get("MATTERMOST_RNB_TECH_WEBHOOK_URL"),
-                json={"text": f"Attention : notre consommation Scaleway a dépassé {threshold}% du budget attendu pour la période commençant le {invoice_start_date}."},
+                json={
+                    "text": f"Attention : notre consommation Scaleway a dépassé {threshold}% du budget attendu pour la période commençant le {invoice_start_date}."
+                },
             )
+
     def test_webhook_401(self):
         with self.env:
             response = self.client.post("/webhook/scaleway/invalid_secret_token")
             self.assertEqual(response.status_code, 401)
             self.assertEqual(response.content, b"Invalid token")
-    
+
     def test_webhook_400(self):
         with self.env:
-            response = self.client.post("/webhook/scaleway/secret_token_xyz", {"key": "value"})
+            response = self.client.post(
+                "/webhook/scaleway/secret_token_xyz", {"key": "value"}
+            )
             self.assertEqual(response.status_code, 400)
             self.assertEqual(response.content, b"Bad Request")
 
     def test_missing_env_var(self):
         with self.env:
             del os.environ["MATTERMOST_RNB_TECH_WEBHOOK_URL"]
-            
+
             invoice_start_date = "01-01-2024"
             treshold = "75"
-            response = self.client.post("/webhook/scaleway/secret_token_xyz", {"invoice_start_date": invoice_start_date, "threshold": treshold})
+            response = self.client.post(
+                "/webhook/scaleway/secret_token_xyz",
+                {"invoice_start_date": invoice_start_date, "threshold": treshold},
+            )
             self.assertEqual(response.status_code, 400)
             self.assertEqual(response.content, b"Bad Request")

--- a/app/webhook/tests.py
+++ b/app/webhook/tests.py
@@ -27,8 +27,10 @@ class WebhookTestCase(TestCase):
 
             response = self.client.post(
                 "/webhook/scaleway/secret_token_xyz",
-                {"invoice_start_date": invoice_start_date, "threshold": threshold},
+                data={"invoice_start_date": invoice_start_date, "threshold": threshold},
+                content_type="application/json",
             )
+
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.content, b"ok")
 

--- a/app/webhook/views.py
+++ b/app/webhook/views.py
@@ -15,8 +15,9 @@ def scaleway(request, secret_token):
             return HttpResponse("Invalid token", status=401)
 
         mattermost_webhook = os.environ.get("MATTERMOST_RNB_TECH_WEBHOOK_URL")
-        invoice_start_date = request.POST.get('invoice_start_date')
-        threshold = request.POST.get('threshold')
+        json_data = json.loads(request.body)
+        invoice_start_date = json_data.get('invoice_start_date')
+        threshold = json_data.get('threshold')
 
         if (
             mattermost_webhook is None


### PR DESCRIPTION
J'avais écrit le code comme si scaleway faisait un appel POST avec un Content/Type "application/x-www-form-urlencoded", alors qu'il le fait avec "application/json". Et la manière de lire la donnée associée dans Django n'est pas la même dans les deux cas. 

Ce qui explique qu'on n'avait pas reçu la notification de billing de la part de scaleway que je pensais voir arriver ce weekend.