### PR TITLE
Adaptation pour upload de gros fichiers sur S3

### DIFF
--- a/app/batid/services/data_gouv_publication.py
+++ b/app/batid/services/data_gouv_publication.py
@@ -8,6 +8,7 @@ import boto3
 import requests
 import hashlib
 import shutil
+import logging
 
 
 def publish():
@@ -24,6 +25,7 @@ def publish():
         publish_on_data_gouv(public_url, archive_size, archive_sha1)
         return True
     except Exception as e:
+        logging.error(f"Error while publishing the RNB on data.gouv.fr: {e}")
         return False
     finally:
         # we always cleanup the directory, no matter what happens

--- a/app/batid/services/data_gouv_publication.py
+++ b/app/batid/services/data_gouv_publication.py
@@ -13,10 +13,7 @@ import logging
 
 def publish():
     # Publish the RNB on data.gouv.fr
-
-    # create a directory with the timestamp
-    directory_name = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    os.mkdir(directory_name)
+    directory_name = create_directory()
 
     try:
         create_rnb_csv_files(directory_name)
@@ -31,6 +28,11 @@ def publish():
         # we always cleanup the directory, no matter what happens
         cleanup_directory(directory_name)
 
+
+def create_directory():
+    directory_name = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    os.mkdir(directory_name)
+    return directory_name
 
 def create_rnb_csv_files(directory_name):
     create_building_csv(directory_name)

--- a/app/batid/services/data_gouv_publication.py
+++ b/app/batid/services/data_gouv_publication.py
@@ -97,8 +97,9 @@ def create_archive(directory_name):
     archive_size = os.path.getsize(archive_path)
 
     archive_sha1 = sha1sum(archive_path)
-    print(archive_size, archive_sha1)
-
+    logging.info(
+        f"zip archive for data.gouv.fr created: {archive_path} ({archive_size} bytes, sha1: {archive_sha1})"
+    )
     return (archive_path, archive_size, archive_sha1)
 
 

--- a/app/batid/services/data_gouv_publication.py
+++ b/app/batid/services/data_gouv_publication.py
@@ -123,11 +123,19 @@ def upload_to_s3(archive_path):
     folder_on_bucket = "data.gouv.fr"
     path_on_bucket = f"{folder_on_bucket}/{archive_name}"
 
+    # Scaleway S3's maximum number of parts for multipart upload
+    MAX_PARTS = 1000
+    # compute the corresponding part size
+    archive_size = os.path.getsize(archive_path)
+    part_size = int(archive_size * 1.2 / MAX_PARTS) + 1
+    config = boto3.s3.transfer.TransferConfig(multipart_chunksize=part_size)
+
     s3.upload_file(
         archive_path,
         S3_SCALEWAY_BUCKET_NAME,
         path_on_bucket,
         ExtraArgs={"ACL": "public-read"},
+        Config=config,
     )
 
     object_exists = s3.get_waiter("object_exists")

--- a/app/batid/services/data_gouv_publication.py
+++ b/app/batid/services/data_gouv_publication.py
@@ -30,9 +30,12 @@ def publish():
 
 
 def create_directory():
-    directory_name = f"datagouvfr_publication_{datetime.now().strftime("%Y-%m-%d_%H-%M-%S")}"
+    directory_name = (
+        f'datagouvfr_publication_{datetime.now().strftime("%Y-%m-%d_%H-%M-%S")}'
+    )
     os.mkdir(directory_name)
     return directory_name
+
 
 def create_rnb_csv_files(directory_name):
     create_building_csv(directory_name)

--- a/app/batid/services/data_gouv_publication.py
+++ b/app/batid/services/data_gouv_publication.py
@@ -12,24 +12,30 @@ import shutil
 
 def publish():
     # Publish the RNB on data.gouv.fr
-    directory_name = create_rnb_csv_files()
-    (archive_path, archive_size, archive_sha1) = create_archive(directory_name)
-    public_url = upload_to_s3(archive_path)
-    publish_on_data_gouv(public_url, archive_size, archive_sha1)
-    cleanup_directory(directory_name)
-    return True
 
-
-def create_rnb_csv_files():
     # create a directory with the timestamp
     directory_name = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     os.mkdir(directory_name)
 
+    try:
+        create_rnb_csv_files(directory_name)
+        (archive_path, archive_size, archive_sha1) = create_archive(directory_name)
+        public_url = upload_to_s3(archive_path)
+        publish_on_data_gouv(public_url, archive_size, archive_sha1)
+        return True
+    except Exception as e:
+        return False
+    finally:
+        # we always cleanup the directory, no matter what happens
+        cleanup_directory(directory_name)
+
+
+def create_rnb_csv_files(directory_name):
     create_building_csv(directory_name)
     create_building_address_csv(directory_name)
     create_address_csv(directory_name)
 
-    return directory_name
+    return True
 
 
 def create_building_csv(directory_name):

--- a/app/batid/services/data_gouv_publication.py
+++ b/app/batid/services/data_gouv_publication.py
@@ -30,7 +30,7 @@ def publish():
 
 
 def create_directory():
-    directory_name = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    directory_name = f"datagouvfr_publication_{datetime.now().strftime("%Y-%m-%d_%H-%M-%S")}"
     os.mkdir(directory_name)
     return directory_name
 
@@ -130,7 +130,7 @@ def upload_to_s3(archive_path):
     MAX_PARTS = 1000
     # compute the corresponding part size
     archive_size = os.path.getsize(archive_path)
-    part_size = int(archive_size * 1.2 / MAX_PARTS) + 1
+    part_size = int(archive_size * 1.2 / MAX_PARTS)
     config = boto3.s3.transfer.TransferConfig(multipart_chunksize=part_size)
 
     s3.upload_file(

--- a/app/batid/tests/test_data_gouv_publication.py
+++ b/app/batid/tests/test_data_gouv_publication.py
@@ -5,6 +5,7 @@ from batid.models import Building, Address
 from django.contrib.gis.geos import GEOSGeometry
 import json
 from batid.services.data_gouv_publication import (
+    create_directory,
     create_rnb_csv_files,
     create_archive,
     cleanup_directory,
@@ -54,7 +55,8 @@ class TestDataGouvPublication(TestCase):
         building.addresses.add(address)
         building.save()
 
-        directory_name = create_rnb_csv_files()
+        directory_name = create_directory()
+        create_rnb_csv_files(directory_name)
 
         # Check if the directory exists
         self.assertTrue(os.path.exists(directory_name))
@@ -126,7 +128,9 @@ class TestDataGouvPublication(TestCase):
             point=geom.point_on_surface,
             ext_ids={"some_source": "1234"},
         )
-        directory_name = create_rnb_csv_files()
+        directory_name = create_directory()
+        create_rnb_csv_files(directory_name)
+        
         (archive_path, archive_size, archive_sha1) = create_archive(directory_name)
 
         # create the mock s3 bucket


### PR DESCRIPTION
Scaleway n'a pas le même nombre de "parts" autorisé lors d'un upload sur son S3 que AWS (1,000 versus 10,000)

Notre lib `boto3` qui sert d'interface avec S3 utilise le défaut de AWS, et les upload qui dépassent 1000 parts échouent.

Le comportement est configurable.

https://stackoverflow.com/questions/53257823/how-to-set-expected-size-option-in-boto3-clients3-upload-fileobj