### PR TITLE
Suppression de shapely

### DIFF
--- a/app/batid/management/commands/sandbox.py
+++ b/app/batid/management/commands/sandbox.py
@@ -5,8 +5,6 @@ from pprint import pprint
 import fiona
 from django.contrib.gis.geos import GEOSGeometry, WKTWriter
 from django.core.management.base import BaseCommand
-from shapely.ops import transform
-from shapely.geometry import shape
 
 from batid.models import Building, Candidate
 from batid.services.candidate import Inspector

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -116,7 +116,6 @@ rfc3986-validator==0.1.1
 rpds-py==0.10.3
 Send2Trash==1.8.2
 sentry-sdk==1.19.1
-shapely==2.0.1
 six==1.16.0
 sniffio==1.3.0
 soupsieve==2.5


### PR DESCRIPTION
On ne semble plus s'en servir.

lié à #331 , car encore mieux que mettre à jour, il y a supprimer !