### PR TITLE
Suppression des services worker_2

### DIFF
--- a/docker-compose.import.yml
+++ b/docker-compose.import.yml
@@ -59,7 +59,7 @@ services:
     command: celery -A app worker --concurrency=6 --loglevel=INFO
     volumes:
       - ./app:/app
-      - ./source_data:/data/downloads
+      - ./source_data:/home/app/source_data
     env_file:
       - ./.env.db_auth.import
       - ./.env.app.import
@@ -70,25 +70,7 @@ services:
       - rabbitmq
       - redis
     container_name: worker
-  worker_2:
-    build:
-      context: .
-      dockerfile: ./app/Dockerfile
-      target: app_worker
-    command: celery -A app worker --concurrency=6 --loglevel=INFO
-    volumes:
-      - ./app:/app
-      - ./source_data:/data/downloads
-    env_file:
-      - ./.env.db_auth.import
-      - ./.env.app.import
-      - ./.env.worker.import
-      - ./.env.rnb.import
-      - ./.env.sentry.import
-    depends_on:
-      - rabbitmq
-      - redis
-    container_name: worker_2
+
   rabbitmq:
     image: rabbitmq:3.9-alpine
     volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -71,26 +71,6 @@ services:
       - rabbitmq
       - redis
     container_name: worker
-  worker_2:
-    build:
-      context: .
-      dockerfile: ./app/Dockerfile
-      target: app_worker
-    command: celery -A app worker --concurrency=6 --loglevel=INFO
-    volumes:
-      - ./app:/app
-      - ./source_data:/data/downloads
-    env_file:
-      - ./.env.db_auth.prod
-      - ./.env.app.prod
-      - ./.env.worker.prod
-      - ./.env.rnb.prod
-      - ./.env.sentry.prod
-      - ./.env.s3_backup.prod
-    depends_on:
-      - rabbitmq
-      - redis
-    container_name: worker_2
   celery_beat:
     build:
       context: .

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -59,7 +59,7 @@ services:
     command: celery -A app worker --concurrency=6 --loglevel=INFO
     volumes:
       - ./app:/app
-      - ./source_data:/data/downloads
+      - ./source_data:/home/app/source_data
     env_file:
       - ./.env.db_auth.staging
       - ./.env.app.staging
@@ -70,25 +70,6 @@ services:
       - rabbitmq
       - redis
     container_name: worker
-  worker_2:
-    build:
-      context: .
-      dockerfile: ./app/Dockerfile
-      target: app_worker
-    command: celery -A app worker --concurrency=6 --loglevel=INFO
-    volumes:
-      - ./app:/app
-      - ./source_data:/data/downloads
-    env_file:
-      - ./.env.db_auth.staging
-      - ./.env.app.staging
-      - ./.env.worker.staging
-      - ./.env.rnb.staging
-      - ./.env.sentry.staging
-    depends_on:
-      - rabbitmq
-      - redis
-    container_name: worker_2
   rabbitmq:
     image: rabbitmq:3.9-alpine
     volumes:


### PR DESCRIPTION
Nous n'avons plus besoin de deux workers par installation. On les supprime de prod, import et staging.