### PR TITLE
remove pillow package

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -86,7 +86,6 @@ pandocfilters==1.5.0
 parso==0.8.3
 pexpect==4.8.0
 pickleshare==0.7.5
-Pillow==9.4.0
 platformdirs==3.10.0
 prometheus-client==0.17.1
 prompt-toolkit==3.0.38


### PR DESCRIPTION
je ne sais pourquoi il était là, je ne pense pas qu'on ait besoin de lui, et la lib présente une vulnérabilité.

Dependabot proposait de mettre le package à jour, je préfère carrément l'enlever. 

Voir #343 
lié à #331 