### PR TITLE
Suppression de version (deprecated), ajout nom projet

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.9"
+name: rnb-coeur
 
 services:
   web:


### PR DESCRIPTION
La propriété `version` est optionnelle, purement informative.
cf : https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-optional

Le nom du projet `name` permet de préfixer le nom des conteneurs et des images.
cf : https://docs.docker.com/compose/compose-file/04-version-and-name/#name-top-level-element