### PR TITLE
Ajout d'un healthcheck sur rabbitmq et dependance entre flower et rabbitmq

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -35,7 +35,7 @@ services:
       db:
         condition: service_healthy
       rabbitmq:
-        condition: service_started
+        condition: service_healthy
       redis:
         condition: service_started
     container_name: web
@@ -64,6 +64,12 @@ services:
     image: rabbitmq:3.9-alpine
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD-SHELL", "rabbitmq-diagnostics -q ping"]
+      interval: 15s
+      retries: 5
+      start_period: 30s
+      timeout: 5s
   redis:
     image: redis:latest
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,12 @@ services:
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
       - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 15s
+      retries: 5
+      start_period: 30s
+      timeout: 5s
   redis:
     image: redis:latest
     ports:
@@ -76,6 +82,9 @@ services:
       - ./.env.worker.dev
     ports:
       - 5555:5555 # docker will expose this ports for flower
+    depends_on:
+      - worker
+      - rabbitmq
 volumes:
   postgres_data:
   rabbitmq_data:


### PR DESCRIPTION
`rabbitmq-diagnostics -q ping` permet de valider que le service est fonctionnel et de ne démarrer les conteneurs dépendants qu'à partir de ce moment-là.
[rabbitmq-diagnostics](https://www.rabbitmq.com/docs/man/rabbitmq-diagnostics.8#ping)
[Docker compose healthcheck](https://docs.docker.com/compose/compose-file/05-services/#healthcheck)