### PR TITLE
Ajout healthcheck pour redis

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -37,7 +37,7 @@ services:
       rabbitmq:
         condition: service_started
       redis:
-        condition: service_started
+        condition: service_healthy
     container_name: web
     restart: always
   db:
@@ -68,7 +68,12 @@ services:
     image: redis:latest
     ports:
       - "6379:6379"
-
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping"]
+      start_period: 10s
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     depends_on:
       - db
       - rabbitmq
+      - redis
     container_name: web
   db:
     image: postgis/postgis:14-master
@@ -62,6 +63,12 @@ services:
     image: redis:latest
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping"]
+      start_period: 10s
+      interval: 5s
+      timeout: 5s
+      retries: 5
   blackd:
     restart: always
     image: docker.io/pyfound/black


### PR DESCRIPTION
`redis-cli ping` permet de vérifier que Redis écoute bien et accepte les connexions, qu'il est donc fonctionnel.
[redis-cli](https://redis.io/docs/latest/operate/rs/references/cli-utilities/redis-cli/#basic-use)
[Docker compose healthcheck](https://docs.docker.com/compose/compose-file/05-services/#healthcheck)