### PR TITLE
Suppression du wait de web container, remplacé par les healthchecks

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -26,9 +26,7 @@ services:
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
       - DOWNLOAD_DIR=/data/downloads
       - MIN_BDG_AREA=5
-      - WAIT_HOSTS=db:5432 rabbitmq:5672 redis:6379
-      - WAIT_BEFORE=8
-    command: sh -c "/wait && python manage.py runserver 0.0.0.0:8000"
+    command: sh -c "python manage.py runserver 0.0.0.0:8000"
     volumes:
       - ./app:/app
     depends_on:


### PR DESCRIPTION
Le conteneur `web` n'a plus besoin d'utiliser `wait` pour attendre le démarrage des autres conteneurs dont il dépend, grâce à la mise en œuvre des healthchecks.
cf #371 #373 #372 