### PR TITLE
Remplacement de docker-compose par docker compose.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build & run docker
-        run: docker-compose -f docker-compose.test.yml up -d --build
+        run: docker compose -f docker-compose.test.yml up -d --build
       - name: Run tests
-        run:  docker-compose -f docker-compose.test.yml exec -T web python manage.py test --exclude-tag=futuristic_search
+        run:  docker compose -f docker-compose.test.yml exec -T web python manage.py test --exclude-tag=futuristic_search


### PR DESCRIPTION
La CI de test utilisait encore la commande `docker-compose` qui est dépréciée au profit de `docker compose`.