### PR TITLE
Ajout d'un min_zoom dans l'API 

### DIFF
--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -198,14 +198,18 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
 
 
 def get_tile(request, x, y, z):
-    tile_dict = url_params_to_tile(x, y, z)
-    sql = tile_sql(tile_dict)
+    # Check the request zoom level
+    if int(z) >= 16:
+        tile_dict = url_params_to_tile(x, y, z)
+        sql = tile_sql(tile_dict)
 
-    with connection.cursor() as cursor:
-        cursor.execute(sql)
-        tile_file = cursor.fetchone()[0]
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+            tile_file = cursor.fetchone()[0]
 
-    return HttpResponse(tile_file, content_type="application/vnd.mapbox-vector-tile")
+        return HttpResponse(tile_file, content_type="application/vnd.mapbox-vector-tile")
+    else:
+        return HttpResponse(status=204)
 
 
 def get_data_gouv_publication_count():

--- a/app/batid/tests/test_tiles.py
+++ b/app/batid/tests/test_tiles.py
@@ -4,7 +4,8 @@ from batid.models import Building
 
 
 class TestVectorTiles(TestCase):
-    def test_tiles_endpoint(self):
+    def setUp(self):
+
         Building.objects.create(
             rnb_id="BDG-1",
             status="constructed",
@@ -19,5 +20,11 @@ class TestVectorTiles(TestCase):
             is_active=False,
         )
 
-        response = self.client.get("/api/alpha/tiles/8166/5902/14.pbf")
+
+    def test_tiles_endpoint(self):
+        response = self.client.get("/api/alpha/tiles/8166/5902/16.pbf")
         self.assertEqual(response.status_code, 200)
+
+    def test_tiles_endpoint_zoomout(self):
+        response = self.client.get("/api/alpha/tiles/8166/5902/12.pbf")
+        self.assertEqual(response.status_code, 204)

--- a/app/batid/tests/test_tiles.py
+++ b/app/batid/tests/test_tiles.py
@@ -20,7 +20,6 @@ class TestVectorTiles(TestCase):
             is_active=False,
         )
 
-
     def test_tiles_endpoint(self):
         response = self.client.get("/api/alpha/tiles/8166/5902/16.pbf")
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Ajout d'une contrainte de zoom min (>= 16) dans l'API pour la génération des tuiles