### PR TITLE
Add start-at option to publish_opendata command

### DIFF
--- a/app/batid/management/commands/publish_opendata.py
+++ b/app/batid/management/commands/publish_opendata.py
@@ -37,5 +37,4 @@ def enqueue_tasks(strate, starting_code=None):
             dpts = dpts[dpts.index(starting_code) :]
 
         for dept in dpts:
-            print(dept)
             app.send_task("batid.tasks.opendata_publish_department", args=[dept])

--- a/app/batid/management/commands/publish_opendata.py
+++ b/app/batid/management/commands/publish_opendata.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
             type=str,
             default="department",
             choices=["country", "department"],
-        ), 
+        ),
         parser.add_argument(
             "--start-at",
             type=str,

--- a/app/batid/management/commands/publish_opendata.py
+++ b/app/batid/management/commands/publish_opendata.py
@@ -16,17 +16,14 @@ class Command(BaseCommand):
             choices=["country", "department"],
         ),
         parser.add_argument(
-            "--start-at",
+            "--start-dpt",
             type=str,
             help="Only for strate=department, allow to start at a specific department code.",
         )
 
     def handle(self, *args, **options):
         strate = options["strate"]
-        if options["start-at"]:
-            starting_code = options["start-at"]
-        else:
-            starting_code = None
+        starting_code = options.get("start_dpt", None)
         enqueue_tasks(strate, starting_code)
 
 
@@ -34,9 +31,11 @@ def enqueue_tasks(strate, starting_code=None):
     if strate == "country":
         app.send_task("batid.tasks.opendata_publish_national")
     elif strate == "department":
-        process = False
-        for dept in dpts_list():
-            if dept == starting_code:
-                process = True
-            if starting_code is None or process is True:
-                app.send_task("batid.tasks.opendata_publish_department", args=[dept])
+        dpts = dpts_list()
+
+        if starting_code is not None:
+            dpts = dpts[dpts.index(starting_code) :]
+
+        for dept in dpts:
+            print(dept)
+            app.send_task("batid.tasks.opendata_publish_department", args=[dept])

--- a/app/batid/management/commands/publish_opendata.py
+++ b/app/batid/management/commands/publish_opendata.py
@@ -14,16 +14,29 @@ class Command(BaseCommand):
             type=str,
             default="department",
             choices=["country", "department"],
+        ), 
+        parser.add_argument(
+            "--start-at",
+            type=str,
+            help="Only for strate=department, allow to start at a specific department code.",
         )
 
     def handle(self, *args, **options):
         strate = options["strate"]
-        enqueue_tasks(strate)
+        if options["start-at"]:
+            starting_code = options["start-at"]
+        else:
+            starting_code = None
+        enqueue_tasks(strate, starting_code)
 
 
-def enqueue_tasks(strate):
+def enqueue_tasks(strate, starting_code=None):
     if strate == "country":
         app.send_task("batid.tasks.opendata_publish_national")
     elif strate == "department":
+        process = False
         for dept in dpts_list():
-            app.send_task("batid.tasks.opendata_publish_department", args=[dept])
+            if dept == starting_code:
+                process = True
+            if starting_code is None or process is True:
+                app.send_task("batid.tasks.opendata_publish_department", args=[dept])

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -37,7 +37,7 @@ services:
     extends:
       file: common-services.yml
       service: worker
-    command: celery -A app worker --concurrency=6 --loglevel=INFO
+    command: celery -A app worker --concurrency=3 --loglevel=INFO
     volumes:
       - ./source_data:/home/app/source_data
     env_file:


### PR DESCRIPTION
Permettre de lancer la génération de l'opendata en commençant à un département précis.