### PR TITLE
Ajout des emails dans les signalements

### DIFF
--- a/app/api_alpha/serializers.py
+++ b/app/api_alpha/serializers.py
@@ -22,7 +22,7 @@ class RNBIdField(serializers.CharField):
 class ContributionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Contribution
-        fields = ["rnb_id", "text"]
+        fields = ["rnb_id", "text", "email"]
 
 
 class AddressSerializer(serializers.ModelSerializer):

--- a/app/batid/admin.py
+++ b/app/batid/admin.py
@@ -38,6 +38,7 @@ class ContributionAdmin(admin.ModelAdmin):
     list_display = (
         "rnb_id",
         "text",
+        "email",
         "created_at",
         "status",
         "fix_issue",


### PR DESCRIPTION
Le champs email était déjà présent dans le model `Contribution`.
J'ajoute le champ au serializer et l'affiche dans le backoffice.