### PR TITLE
Choix de date pour l'import de la BD Topo

### DIFF
--- a/app/batid/services/imports/import_bdtopo.py
+++ b/app/batid/services/imports/import_bdtopo.py
@@ -18,7 +18,6 @@ from django.db import transaction
 from batid.models import Building
 from batid.models import BuildingImport
 from batid.models import Candidate
-from batid.services.administrative_areas import dpts_list
 from batid.services.imports import building_import_history
 from batid.services.source import BufferToCopy
 from batid.services.source import Source

--- a/app/batid/services/imports/import_bdtopo.py
+++ b/app/batid/services/imports/import_bdtopo.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import date
 from datetime import datetime
 from datetime import timezone
+from typing import Optional
 
 import fiona
 import psycopg2
@@ -24,29 +25,29 @@ from batid.services.source import Source
 from batid.utils.geo import fix_nested_shells
 
 
-def create_bdtopo_full_import_tasks(dpt_list=None) -> list:
+def create_bdtopo_full_import_tasks(
+    dpt_list: Optional[list] = None, release_date: Optional[str] = None
+) -> list:
 
     tasks = []
 
     bulk_launch_uuid = uuid.uuid4()
 
-    if not dpt_list:
-        dpt_list = dpts_list()
-
     for dpt in dpt_list:
 
-        dpt_tasks = create_bdtopo_dpt_import_tasks(dpt, bulk_launch_uuid)
+        dpt_tasks = create_bdtopo_dpt_import_tasks(dpt, release_date, bulk_launch_uuid)
         tasks.extend(dpt_tasks)
 
     return tasks
 
 
-def create_bdtopo_dpt_import_tasks(dpt: str, bulk_launch_id=None) -> list:
+def create_bdtopo_dpt_import_tasks(
+    dpt: str, release_date: str, bulk_launch_id=None
+) -> list:
 
     tasks = []
 
-    most_recent_date = bdtopo_release_before()
-    src_params = bdtopo_src_params(dpt, most_recent_date)
+    src_params = bdtopo_src_params(dpt, release_date)
 
     dl_task = Signature(
         "batid.tasks.dl_source",
@@ -210,7 +211,7 @@ def _bdtopo_dpt_projection(dpt: str) -> str:
     return projs.get(dpt, default_proj)
 
 
-def bdtopo_release_before(before: date = None) -> str:
+def bdtopo_recente_release_date(before: date = None) -> str:
 
     # If no date is provided, we use the current date
     if before is None:

--- a/app/batid/services/imports/import_bdtopo.py
+++ b/app/batid/services/imports/import_bdtopo.py
@@ -24,9 +24,7 @@ from batid.services.source import Source
 from batid.utils.geo import fix_nested_shells
 
 
-def create_bdtopo_full_import_tasks(
-    dpt_list: Optional[list] = None, release_date: Optional[str] = None
-) -> list:
+def create_bdtopo_full_import_tasks(dpt_list: list, release_date: str) -> list:
 
     tasks = []
 
@@ -210,7 +208,7 @@ def _bdtopo_dpt_projection(dpt: str) -> str:
     return projs.get(dpt, default_proj)
 
 
-def bdtopo_recente_release_date(before: date = None) -> str:
+def bdtopo_recente_release_date(before: Optional[date] = None) -> str:
 
     # If no date is provided, we use the current date
     if before is None:

--- a/app/batid/tasks.py
+++ b/app/batid/tasks.py
@@ -76,15 +76,17 @@ def convert_bdtopo(src_params, bulk_launch_uuid=None):
 
 @notify_if_error
 @shared_task(autoretry_for=(Exception,), retry_kwargs={"max_retries": 3})
-def queue_full_bdtopo_import(dpts: Optional[str] = None, before: Optional[str] = None):
+def queue_full_bdtopo_import(
+    dpts_str: Optional[str] = None, before: Optional[str] = None
+):
 
     notify_tech(
-        f"Queuing full BDTopo import tasks.  Dpts: {dpts}  Released before: {before}"
+        f"Queuing full BDTopo import tasks.  Dpts: {dpts_str}  Released before: {before}"
     )
 
     # Default to all dpts
-    if dpts:
-        dpts = dpts.split(",")
+    if dpts_str:
+        dpts = dpts_str.split(",")
     else:
         dpts = dpts_list()
 

--- a/app/batid/tasks.py
+++ b/app/batid/tasks.py
@@ -13,10 +13,8 @@ from batid.services.candidate import Inspector
 from batid.services.data_gouv_publication import publish
 from batid.services.imports.import_bdnb_2023_01 import import_bdnd_2023_01_addresses
 from batid.services.imports.import_bdnb_2023_01 import import_bdnd_2023_01_bdgs
-from batid.services.imports.import_bdtopo import (
-    create_bdtopo_full_import_tasks,
-    bdtopo_recente_release_date,
-)
+from batid.services.imports.import_bdtopo import bdtopo_recente_release_date
+from batid.services.imports.import_bdtopo import create_bdtopo_full_import_tasks
 from batid.services.imports.import_bdtopo import create_candidate_from_bdtopo
 from batid.services.imports.import_cities import import_etalab_cities
 from batid.services.imports.import_dgfip_ads import (

--- a/app/batid/tests/test_bdtopo.py
+++ b/app/batid/tests/test_bdtopo.py
@@ -3,7 +3,7 @@ from datetime import date
 from django.test import TransactionTestCase
 
 from batid.services.imports.import_bdtopo import _known_bdtopo_id
-from batid.services.imports.import_bdtopo import bdtopo_release_before
+from batid.services.imports.import_bdtopo import bdtopo_recente_release_date
 from batid.tests.helpers import create_default_bdg
 
 
@@ -11,11 +11,11 @@ class ReleaseDate(TransactionTestCase):
     def test(self):
 
         # Test normal case
-        release = bdtopo_release_before(date(2024, 5, 24))
+        release = bdtopo_recente_release_date(date(2024, 5, 24))
         self.assertEqual(release, "2024-03-15")
 
         # Test on the day of a new release
-        release = bdtopo_release_before(date(2025, 3, 15))
+        release = bdtopo_recente_release_date(date(2025, 3, 15))
         self.assertEqual(release, "2024-12-15")
 
 


### PR DESCRIPTION
J'ai voulu relancer l'import de la BD Topo suite au blocage de RabbitMQ hier mais, pas de chance, on se retrouve dans un créneau où la date du dernier millésime vient de passer (2024-06-15) mais celui-ci n'est pas encore publié (il devrait l'être dans qq semaines).

J'ajoute un paramètre de date à la tâche permettant de lancer un import complet de la BD Topo :

```shell
docker exec -ti web celery call batid.tasks.queue_full_bdtopo_import --kwargs='{"before":"2024-06-01"}'
```