### PR TITLE
Ajout du fichier .env.nginx-encrypt.dev dans le gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 .env.sentry.import
 .env.sentry.sandbox
 
+.env.nginx-encrypt.dev
 .env.nginx-encrypt.prod
 .env.nginx-encrypt.staging
 .env.nginx-encrypt.import


### PR DESCRIPTION
Comme indiqué dans la documentation d'installation (https://rnb-fr.gitbook.io/documentation/repository-rnb-coeur/installation), il faut dupliquer des fichiers .env pour se créer une configuration en local.
Le fichier `.env.nginx-encrypt.dev` est le seul à ne pas être ignoré dans Git.