### PR TITLE
Empêcher la création d'un ADS avec un RNB ID et une géométrie

### DIFF
--- a/app/api_alpha/tests/test_ads.py
+++ b/app/api_alpha/tests/test_ads.py
@@ -459,6 +459,53 @@ class ADSEndpointsWithAuthTest(APITestCase):
         r_data = r.json()
         self.assertDictEqual(r_data, expected)
 
+    def test_create_ads_without_shape_and_rnd_id(self):
+        data = {
+            "file_number": "ADS-TEST-3",
+            "decided_at": "2019-01-02",
+            "buildings_operations": [
+                {
+                    "operation": "build",
+                }
+            ],
+        }
+        r = self.client.post(
+            "/api/alpha/ads/", data=json.dumps(data), content_type="application/json"
+        )
+
+        self.assertEqual(r.status_code, 400)
+
+        r_data = r.json()
+        for op in r_data["buildings_operations"]:
+            if "non_field_errors" in op:
+                self.assertIn("Either rnb_id or shape is required.", op["non_field_errors"])
+
+    def test_create_ads_with_shape_and_rnd_id(self):
+        data = {
+            "file_number": "ADS-TEST-3",
+            "decided_at": "2019-01-02",
+            "buildings_operations": [
+                {
+                    "operation": "build",
+                    "rnb_id": "BDGSRNBBIDID",
+                    "shape": {
+                        "type": "Point",
+                        "coordinates": [5.724331358994107, 45.18157371019683],
+                    },
+                }
+            ],
+        }
+        r = self.client.post(
+            "/api/alpha/ads/", data=json.dumps(data), content_type="application/json"
+        )
+
+        self.assertEqual(r.status_code, 400)
+
+        r_data = r.json()
+        for op in r_data["buildings_operations"]:
+            if "non_field_errors" in op:
+                self.assertIn("You can't provide a rnb_id and a shape, you should remove the shape.", op["non_field_errors"])
+
     def test_ads_create_with_multipolygon(self):
         data = {
             "file_number": "ADS-TEST-NEW-BDG-MP",

--- a/app/api_alpha/tests/test_ads.py
+++ b/app/api_alpha/tests/test_ads.py
@@ -478,7 +478,9 @@ class ADSEndpointsWithAuthTest(APITestCase):
         r_data = r.json()
         for op in r_data["buildings_operations"]:
             if "non_field_errors" in op:
-                self.assertIn("Either rnb_id or shape is required.", op["non_field_errors"])
+                self.assertIn(
+                    "Either rnb_id or shape is required.", op["non_field_errors"]
+                )
 
     def test_create_ads_with_shape_and_rnd_id(self):
         data = {
@@ -504,7 +506,10 @@ class ADSEndpointsWithAuthTest(APITestCase):
         r_data = r.json()
         for op in r_data["buildings_operations"]:
             if "non_field_errors" in op:
-                self.assertIn("You can't provide a rnb_id and a shape, you should remove the shape.", op["non_field_errors"])
+                self.assertIn(
+                    "You can't provide a rnb_id and a shape, you should remove the shape.",
+                    op["non_field_errors"],
+                )
 
     def test_ads_create_with_multipolygon(self):
         data = {

--- a/app/api_alpha/tests/test_ads.py
+++ b/app/api_alpha/tests/test_ads.py
@@ -642,7 +642,7 @@ class ADSEndpointsWithAuthTest(APITestCase):
                 {
                     "operation": "build",
                     "rnb_id": "BDGSADSSTWO2",
-                    'shape': None,
+                    "shape": None,
                 }
             ],
         }

--- a/app/api_alpha/tests/test_ads.py
+++ b/app/api_alpha/tests/test_ads.py
@@ -622,11 +622,7 @@ class ADSEndpointsWithAuthTest(APITestCase):
             "buildings_operations": [
                 {
                     "operation": "build",
-                    "rnb_id": "BDGSADSSONE1",
-                    "shape": {
-                        "type": "Point",
-                        "coordinates": [5.720861502527286, 45.18380982645842],
-                    },
+                    "rnb_id": "BDGSADSSTWO2",
                 }
             ],
         }
@@ -645,11 +641,8 @@ class ADSEndpointsWithAuthTest(APITestCase):
             "buildings_operations": [
                 {
                     "operation": "build",
-                    "rnb_id": "BDGSADSSONE1",
-                    "shape": {
-                        "type": "Point",
-                        "coordinates": [5.720861502527286, 45.18380982645842],
-                    },
+                    "rnb_id": "BDGSADSSTWO2",
+                    'shape': None,
                 }
             ],
         }

--- a/app/api_alpha/validators.py
+++ b/app/api_alpha/validators.py
@@ -18,6 +18,9 @@ class BdgInADSValidator:
         if rnb_id is None and shape is None:
             raise serializers.ValidationError("Either rnb_id or shape is required.")
 
+        if rnb_id is not None and shape is not None:
+            raise serializers.ValidationError("You can't provide a rnb_id and a shape, you should remove the shape.")
+
         # if shape is not None:
         #     try:
         #         print("-- transform !!")

--- a/app/api_alpha/validators.py
+++ b/app/api_alpha/validators.py
@@ -19,7 +19,9 @@ class BdgInADSValidator:
             raise serializers.ValidationError("Either rnb_id or shape is required.")
 
         if rnb_id is not None and shape is not None:
-            raise serializers.ValidationError("You can't provide a rnb_id and a shape, you should remove the shape.")
+            raise serializers.ValidationError(
+                "You can't provide a rnb_id and a shape, you should remove the shape."
+            )
 
         # if shape is not None:
         #     try:


### PR DESCRIPTION
Il est possible de créer un ADS avec un RNB ID et une géométrie.
Étant donné que le RNB ID est déjà lié à une géométrie de source sûre, sauvegarder une autre géométrie en plus dans l'ADS est inutile et source d'erreur.