### PR TITLE
Suppression des dossier BD Topo d'un département après import

### DIFF
--- a/app/batid/services/administrative_areas.py
+++ b/app/batid/services/administrative_areas.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import requests
 
 
@@ -131,8 +133,21 @@ def dpt_list_overseas():
     return ["971", "972", "973", "974", "975", "976", "977", "978"]
 
 
-def dpts_list():
-    return dpt_list_metropole() + dpt_list_overseas()
+def dpts_list(start: Optional[str] = None, end: Optional[str] = None):
+    """
+    :param start: First department to be included
+    :param end: Last department to be included
+    :return: list of departments in France
+    """
 
+    all = dpt_list_metropole() + dpt_list_overseas()
 
-# Returns a dict representation of the WGS84 bbox of the metropolitan area
+    start_idx = 0
+    if start:
+        start_idx = all.index(start)
+
+    end_idx = len(all)
+    if end:
+        end_idx = all.index(end) + 1
+
+    return all[start_idx:end_idx]

--- a/app/batid/services/imports/import_bdtopo.py
+++ b/app/batid/services/imports/import_bdtopo.py
@@ -123,7 +123,7 @@ def create_candidate_from_bdtopo(src_params, bulk_launch_uuid=None):
         print("- remove buffer")
         os.remove(buffer.path)
         print(f"- remove {src.uncompress_folder} folder")
-        shutil.rmtree(src.uncompress_folder)
+        src.remove_uncompressed_folder()
 
 
 def _known_bdtopo_id(bdtopo_id: str) -> bool:

--- a/app/batid/services/imports/import_bdtopo.py
+++ b/app/batid/services/imports/import_bdtopo.py
@@ -1,6 +1,7 @@
 import json
 import os
 import random
+import shutil
 import uuid
 from datetime import date
 from datetime import datetime
@@ -121,6 +122,8 @@ def create_candidate_from_bdtopo(src_params, bulk_launch_uuid=None):
 
         print("- remove buffer")
         os.remove(buffer.path)
+        print(f"- remove {src.uncompress_folder} folder")
+        shutil.rmtree(src.uncompress_folder)
 
 
 def _known_bdtopo_id(bdtopo_id: str) -> bool:

--- a/app/batid/services/imports/import_bdtopo.py
+++ b/app/batid/services/imports/import_bdtopo.py
@@ -1,7 +1,6 @@
 import json
 import os
 import random
-import shutil
 import uuid
 from datetime import date
 from datetime import datetime

--- a/app/batid/services/source.py
+++ b/app/batid/services/source.py
@@ -1,6 +1,7 @@
 import csv
 import gzip
 import os
+import shutil
 import tarfile
 import zipfile
 
@@ -182,6 +183,10 @@ class Source:
             return
 
         os.remove(self.dl_path)
+
+    def remove_uncompressed_folder(self):
+        if self.is_archive:
+            shutil.rmtree(self.uncompress_folder)
 
     def find(self, filename):
         root_dir = self.abs_dir

--- a/app/batid/tasks.py
+++ b/app/batid/tasks.py
@@ -77,24 +77,22 @@ def convert_bdtopo(src_params, bulk_launch_uuid=None):
 @notify_if_error
 @shared_task(autoretry_for=(Exception,), retry_kwargs={"max_retries": 3})
 def queue_full_bdtopo_import(
-    dpts_str: Optional[str] = None, before: Optional[str] = None
+    dpts_start: Optional[str] = None,
+    dpts_end: Optional[str] = None,
+    released_before: Optional[str] = None,
 ):
 
     notify_tech(
-        f"Queuing full BDTopo import tasks.  Dpts: {dpts_str}  Released before: {before}"
+        f"Queuing full BDTopo import tasks.  Dpt start: {dpts_start}, dpt end: {dpts_end}.  Released before: {released_before}"
     )
 
-    # Default to all dpts
-    if dpts_str:
-        dpts = dpts_str.split(",")
-    else:
-        dpts = dpts_list()
+    # Get list of dpts
+    dpts = dpts_list(dpts_start, dpts_end)
 
     # Default release date to most recent one
-    if before:
+    if released_before:
         # date str to date object
-        before_date = datetime.strptime(before, "%Y-%m-%d").date()
-
+        before_date = datetime.strptime(released_before, "%Y-%m-%d").date()
         release_date = bdtopo_recente_release_date(before_date)
     else:
         release_date = bdtopo_recente_release_date()

--- a/app/batid/tasks.py
+++ b/app/batid/tasks.py
@@ -77,17 +77,17 @@ def convert_bdtopo(src_params, bulk_launch_uuid=None):
 @notify_if_error
 @shared_task(autoretry_for=(Exception,), retry_kwargs={"max_retries": 3})
 def queue_full_bdtopo_import(
-    dpts_start: Optional[str] = None,
-    dpts_end: Optional[str] = None,
+    dpt_start: Optional[str] = None,
+    dpt_end: Optional[str] = None,
     released_before: Optional[str] = None,
 ):
 
     notify_tech(
-        f"Queuing full BDTopo import tasks.  Dpt start: {dpts_start}, dpt end: {dpts_end}.  Released before: {released_before}"
+        f"Queuing full BDTopo import tasks.  Dpt start: {dpt_start}, dpt end: {dpt_end}.  Released before: {released_before}"
     )
 
     # Get list of dpts
-    dpts = dpts_list(dpts_start, dpts_end)
+    dpts = dpts_list(dpt_start, dpt_end)
 
     # Default release date to most recent one
     if released_before:

--- a/app/batid/tests/test_import_bdtopo.py
+++ b/app/batid/tests/test_import_bdtopo.py
@@ -23,8 +23,10 @@ class ImportBDTopo(TransactionTestCase):
         bdg.save()
 
     @patch("batid.services.imports.import_bdtopo.Source.find")
-    def test_import_bdtopo_2023_09(self, sourceMock):
-        sourceMock.return_value = helpers.fixture_path("bdtopo_2023_09_38.shp")
+    @patch("batid.services.imports.import_bdtopo.Source.remove_uncompressed_folder")
+    def test_import_bdtopo_2023_09(self, sourceRemoveFolderMock, sourceFindMock):
+        sourceFindMock.return_value = helpers.fixture_path("bdtopo_2023_09_38.shp")
+        sourceRemoveFolderMock.return_value = None
 
         src_params = bdtopo_src_params("38", "2023-09-15")
 


### PR DESCRIPTION
Le disque de prod se remplit rapidement avec le nouvel import de la BD Topo. Avec cette PR, on supprime les dossiers contenant la BD Topo d'un département après l'import de ceux-ci.

Aussi, on ajoute deux paramètres permettant de faire un import uniquement entre tel et tel département.