### PR TITLE
Update python to version 3.12.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: [3.12]
     steps:
       - uses: actions/checkout@v3
       - name: Build & run docker

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.14 as base
+FROM python:3.12.4 as base
 
 WORKDIR /app
 

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -5,7 +5,7 @@ description = "RNB's backend code"
 authors = ["RNB team <tech@rnb.beta.gouv.fr>"]
 
 [tool.poetry.dependencies]
-python = "3.10.14"
+python = "3.12.4"
 boto3 = "~1.34.126"
 Django = "~5.0.7"
 drf-spectacular = "~0.27.1"


### PR DESCRIPTION
Mise à jour de la version Python utilisée.

Les changelogs sont [ici](https://docs.python.org/3/whatsnew/3.11.html#what-s-new-in-python-3-11) et i[ci](https://docs.python.org/3/whatsnew/3.12.html). J'ai regardé les section sur les deprecation et les removed features, j'ai rien vu qui m'a sauté aux yeux.

Les tests passent et le projet tourne bien en local chez moi.