### PR TITLE
Mise à jour postgres / postgis version dans docker compose

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -45,7 +45,7 @@ services:
     container_name: web
 
   db:
-    image: postgis/postgis:14-master
+    image: postgis/postgis:15-3.3
     platform: linux/amd64
     shm_size: 1gb
     volumes:


### PR DESCRIPTION
Je vais migrer notre base de prod vers Postgres 15.
La [release](https://www.postgresql.org/docs/release/15.0/) note mentionne notamment "Performance improvements, particularly for in-memory and on-disk sorting" ce qui pourra nous intéresser.

Je vous laisse voir comment vous gérez le passage de Postgres 14 vers 15 en local chez vous. De mon côté ma base locale était quasiment vide, je l'ai donc supprimée, puis j'en ai recréé une nouvelle en lui appliquant les migrations de Django (`python manage.py migrate`).