### PR TITLE
Ajout de l'annotation @extend_schema de DRF Spectacular pour documenter nos APIs

### DIFF
--- a/app/api_alpha/serializers.py
+++ b/app/api_alpha/serializers.py
@@ -40,33 +40,37 @@ class AddressSerializer(serializers.ModelSerializer):
             "city_insee_code",
         ]
         extra_kwargs = {
-            'id': {'help_text': "02191_0020_00003"},
-            'source': {'help_text': 'bdnb'},
-            'street_number': {'help_text': '3'},
-            'street_rep': {'help_text': ''},
-            'street_name': {'help_text': 'de l\'eglise'},
-            'street_type': {'help_text': 'rue'},
-            'city_name': {'help_text': 'Chivy-lès-Étouvelles'},
-            'city_zipcode': {'help_text': '02000'},
-            'city_insee_code': {'help_text': '02191'},
+            "id": {"help_text": "02191_0020_00003"},
+            "source": {"help_text": "bdnb"},
+            "street_number": {"help_text": "3"},
+            "street_rep": {"help_text": ""},
+            "street_name": {"help_text": "de l'eglise"},
+            "street_type": {"help_text": "rue"},
+            "city_name": {"help_text": "Chivy-lès-Étouvelles"},
+            "city_zipcode": {"help_text": "02000"},
+            "city_insee_code": {"help_text": "02191"},
         }
 
 
 class ExtIdSerializer(serializers.Serializer):
-    id = serializers.CharField(help_text='bdnb-bc-3B85-TYM9-FDSX')
-    source = serializers.CharField(help_text='bdnb')
-    created_at = serializers.DateTimeField(help_text='2023-12-07T13:20:58.310444+00:00')
-    source_version = serializers.CharField(help_text='2023_01')
+    id = serializers.CharField(help_text="bdnb-bc-3B85-TYM9-FDSX")
+    source = serializers.CharField(help_text="bdnb")
+    created_at = serializers.DateTimeField(help_text="2023-12-07T13:20:58.310444+00:00")
+    source_version = serializers.CharField(help_text="2023_01")
 
 
 class BuildingSerializer(serializers.ModelSerializer):
-    point = serializers.DictField(source="point_geojson", read_only=True, help_text='''{
+    point = serializers.DictField(
+        source="point_geojson",
+        read_only=True,
+        help_text="""{
                             "type": "Point",
                             "coordinates": [
                                 3.584410393780201,
                                 49.52799819019749
                             ]
-                        }''')
+                        }""",
+    )
     addresses = AddressSerializer(
         many=True, read_only=True, source="addresses_read_only"
     )
@@ -83,9 +87,9 @@ class BuildingSerializer(serializers.ModelSerializer):
             "is_active",
         ]
         extra_kwargs = {
-            'rnb_id': {'help_text': "QBAAG16VCJWA"},
-            'status': {'help_text': 'constructed'},
-            'is_active': {'help_text': 'true'},
+            "rnb_id": {"help_text": "QBAAG16VCJWA"},
+            "status": {"help_text": "constructed"},
+            "is_active": {"help_text": "true"},
         }
 
 
@@ -159,7 +163,10 @@ class BuildingClosestQuerySerializer(serializers.Serializer):
 class BuildingsADSSerializer(serializers.ModelSerializer):
     # building = BdgInAdsSerializer()
     rnb_id = RNBIdField(
-        validators=[ads_validate_rnbid], required=False, allow_null=True, help_text='A1B2C3A1B2C3'
+        validators=[ads_validate_rnbid],
+        required=False,
+        allow_null=True,
+        help_text="A1B2C3A1B2C3",
     )
 
     operation = serializers.ChoiceField(
@@ -169,7 +176,7 @@ class BuildingsADSSerializer(serializers.ModelSerializer):
             "invalid_choice": "'{input}' is not a valid operation. Valid operations are: "
             + f"{BuildingADSLogic.OPERATIONS}."
         },
-        help_text='build'
+        help_text="build",
     )
 
     class Meta:
@@ -179,15 +186,17 @@ class BuildingsADSSerializer(serializers.ModelSerializer):
         validators = [BdgInADSValidator()]
 
         extra_kwargs = {
-            'rnb_id': {'help_text': "A1B2C3A1B2C3"},
-            'shape': {'help_text': '''{
+            "rnb_id": {"help_text": "A1B2C3A1B2C3"},
+            "shape": {
+                "help_text": """{
                                         "type": "Point",
                                         "coordinates": [
                                             5.722961565015281,
                                             45.1851103238598
                                         ]
-                                    }'''},
-            'operation': {'help_text': 'demolish'},
+                                    }"""
+            },
+            "operation": {"help_text": "demolish"},
         }
 
     def create(self, validated_data):
@@ -197,14 +206,16 @@ class BuildingsADSSerializer(serializers.ModelSerializer):
 class ADSSerializer(serializers.ModelSerializer):
     file_number = serializers.CharField(
         required=True,
-        help_text='TEST03818519U9999',
+        help_text="TEST03818519U9999",
         validators=[
             UniqueValidator(
                 queryset=ADS.objects.all(), message="This file number already exists"
             )
         ],
     )
-    decided_at = serializers.DateField(required=True, format="%Y-%m-%d", help_text='2023-06-01')
+    decided_at = serializers.DateField(
+        required=True, format="%Y-%m-%d", help_text="2023-06-01"
+    )
     buildings_operations = BuildingsADSSerializer(many=True, required=True)
 
     creator = serializers.HiddenField(default=serializers.CurrentUserDefault())

--- a/app/api_alpha/serializers.py
+++ b/app/api_alpha/serializers.py
@@ -39,14 +39,38 @@ class AddressSerializer(serializers.ModelSerializer):
             "city_zipcode",
             "city_insee_code",
         ]
+        extra_kwargs = {
+            'id': {'help_text': "02191_0020_00003"},
+            'source': {'help_text': 'bdnb'},
+            'street_number': {'help_text': '3'},
+            'street_rep': {'help_text': ''},
+            'street_name': {'help_text': 'de l\'eglise'},
+            'street_type': {'help_text': 'rue'},
+            'city_name': {'help_text': 'Chivy-lès-Étouvelles'},
+            'city_zipcode': {'help_text': '02000'},
+            'city_insee_code': {'help_text': '02191'},
+        }
+
+
+class ExtIdSerializer(serializers.Serializer):
+    id = serializers.CharField(help_text='bdnb-bc-3B85-TYM9-FDSX')
+    source = serializers.CharField(help_text='bdnb')
+    created_at = serializers.DateTimeField(help_text='2023-12-07T13:20:58.310444+00:00')
+    source_version = serializers.CharField(help_text='2023_01')
 
 
 class BuildingSerializer(serializers.ModelSerializer):
-    point = serializers.DictField(source="point_geojson", read_only=True)
+    point = serializers.DictField(source="point_geojson", read_only=True, help_text='''{
+                            "type": "Point",
+                            "coordinates": [
+                                3.584410393780201,
+                                49.52799819019749
+                            ]
+                        }''')
     addresses = AddressSerializer(
         many=True, read_only=True, source="addresses_read_only"
     )
-    ext_ids = serializers.JSONField(read_only=True)
+    ext_ids = ExtIdSerializer(many=True, read_only=True)
 
     class Meta:
         model = Building
@@ -58,6 +82,11 @@ class BuildingSerializer(serializers.ModelSerializer):
             "ext_ids",
             "is_active",
         ]
+        extra_kwargs = {
+            'rnb_id': {'help_text': "QBAAG16VCJWA"},
+            'status': {'help_text': 'constructed'},
+            'is_active': {'help_text': 'true'},
+        }
 
 
 class GuessBuildingSerializer(serializers.ModelSerializer):
@@ -130,7 +159,7 @@ class BuildingClosestQuerySerializer(serializers.Serializer):
 class BuildingsADSSerializer(serializers.ModelSerializer):
     # building = BdgInAdsSerializer()
     rnb_id = RNBIdField(
-        validators=[ads_validate_rnbid], required=False, allow_null=True
+        validators=[ads_validate_rnbid], required=False, allow_null=True, help_text='A1B2C3A1B2C3'
     )
 
     operation = serializers.ChoiceField(
@@ -140,6 +169,7 @@ class BuildingsADSSerializer(serializers.ModelSerializer):
             "invalid_choice": "'{input}' is not a valid operation. Valid operations are: "
             + f"{BuildingADSLogic.OPERATIONS}."
         },
+        help_text='build'
     )
 
     class Meta:
@@ -148,6 +178,18 @@ class BuildingsADSSerializer(serializers.ModelSerializer):
         fields = ["rnb_id", "shape", "operation"]
         validators = [BdgInADSValidator()]
 
+        extra_kwargs = {
+            'rnb_id': {'help_text': "A1B2C3A1B2C3"},
+            'shape': {'help_text': '''{
+                                        "type": "Point",
+                                        "coordinates": [
+                                            5.722961565015281,
+                                            45.1851103238598
+                                        ]
+                                    }'''},
+            'operation': {'help_text': 'demolish'},
+        }
+
     def create(self, validated_data):
         return BuildingADS(**validated_data)
 
@@ -155,13 +197,14 @@ class BuildingsADSSerializer(serializers.ModelSerializer):
 class ADSSerializer(serializers.ModelSerializer):
     file_number = serializers.CharField(
         required=True,
+        help_text='TEST03818519U9999',
         validators=[
             UniqueValidator(
                 queryset=ADS.objects.all(), message="This file number already exists"
             )
         ],
     )
-    decided_at = serializers.DateField(required=True, format="%Y-%m-%d")
+    decided_at = serializers.DateField(required=True, format="%Y-%m-%d", help_text='2023-06-01')
     buildings_operations = BuildingsADSSerializer(many=True, required=True)
 
     creator = serializers.HiddenField(default=serializers.CurrentUserDefault())

--- a/app/api_alpha/urls.py
+++ b/app/api_alpha/urls.py
@@ -5,7 +5,7 @@ from drf_spectacular.views import SpectacularRedocView
 from rest_framework import routers
 from rest_framework.authtoken import views as auth_views
 
-from api_alpha.views import AdsTokenView, GetVectorTileView
+from api_alpha.views import AdsTokenView
 from api_alpha.views import ADSViewSet
 from api_alpha.views import BuildingClosestView
 from api_alpha.views import BuildingGuessView
@@ -14,6 +14,7 @@ from api_alpha.views import ContributionsViewSet
 from api_alpha.views import get_diff
 from api_alpha.views import get_stats
 from api_alpha.views import get_tile_shape
+from api_alpha.views import GetVectorTileView
 
 # Routers provide an easy way of automatically determining the URL conf.
 router = routers.DefaultRouter()

--- a/app/api_alpha/urls.py
+++ b/app/api_alpha/urls.py
@@ -5,7 +5,7 @@ from drf_spectacular.views import SpectacularRedocView
 from rest_framework import routers
 from rest_framework.authtoken import views as auth_views
 
-from api_alpha.views import AdsTokenView
+from api_alpha.views import AdsTokenView, GetVectorTileView
 from api_alpha.views import ADSViewSet
 from api_alpha.views import BuildingClosestView
 from api_alpha.views import BuildingGuessView
@@ -13,7 +13,6 @@ from api_alpha.views import BuildingViewSet
 from api_alpha.views import ContributionsViewSet
 from api_alpha.views import get_diff
 from api_alpha.views import get_stats
-from api_alpha.views import get_tile_point
 from api_alpha.views import get_tile_shape
 
 # Routers provide an easy way of automatically determining the URL conf.
@@ -39,7 +38,7 @@ urlpatterns = [
     path("ads/token/", AdsTokenView.as_view()),
     path("", include(router.urls)),
     path("login/", auth_views.obtain_auth_token),
-    path("tiles/<int:x>/<int:y>/<int:z>.pbf", get_tile_point),
+    path("tiles/<int:x>/<int:y>/<int:z>.pbf", GetVectorTileView.as_view()),
     path("tiles/shapes/<int:x>/<int:y>/<int:z>.pbf", get_tile_shape),
     # path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]

--- a/app/api_alpha/utils/drf_spectacular_extension.py
+++ b/app/api_alpha/utils/drf_spectacular_extension.py
@@ -2,9 +2,10 @@ from drf_spectacular.extensions import OpenApiSerializerFieldExtension
 from rest_framework import serializers
 
 excluded_endpoints = [
-    '/api/alpha/login/',
-    '/api/alpha/schema/',
+    "/api/alpha/login/",
+    "/api/alpha/schema/",
 ]
+
 
 def filter_endpoints_hook(endpoints):
     return [endpoint for endpoint in endpoints if endpoint[0] not in excluded_endpoints]
@@ -17,10 +18,12 @@ class AddExampleToOpenAPIFields(OpenApiSerializerFieldExtension):
     match_subclasses = True
 
     def map_serializer_field(self, auto_schema, direction):
-        default = auto_schema._map_serializer_field(self.target, direction, bypass_extensions=True);
+        default = auto_schema._map_serializer_field(
+            self.target, direction, bypass_extensions=True
+        )
 
         if self.target.help_text is not None:
-            default['example'] = self.target.help_text
-            default.pop('description', None)
+            default["example"] = self.target.help_text
+            default.pop("description", None)
 
         return default

--- a/app/api_alpha/utils/drf_spectacular_extension.py
+++ b/app/api_alpha/utils/drf_spectacular_extension.py
@@ -24,6 +24,5 @@ class AddExampleToOpenAPIFields(OpenApiSerializerFieldExtension):
 
         if self.target.help_text is not None:
             default["example"] = self.target.help_text
-            default.pop("description", None)
 
         return default

--- a/app/api_alpha/utils/drf_spectacular_extension.py
+++ b/app/api_alpha/utils/drf_spectacular_extension.py
@@ -1,0 +1,26 @@
+from drf_spectacular.extensions import OpenApiSerializerFieldExtension
+from rest_framework import serializers
+
+excluded_endpoints = [
+    '/api/alpha/login/',
+    '/api/alpha/schema/',
+]
+
+def filter_endpoints_hook(endpoints):
+    return [endpoint for endpoint in endpoints if endpoint[0] not in excluded_endpoints]
+
+
+# This DRF Spectacular extension move the help_text from a serialized field
+# from the "description" property to the "example" property
+class AddExampleToOpenAPIFields(OpenApiSerializerFieldExtension):
+    target_class = serializers.Field
+    match_subclasses = True
+
+    def map_serializer_field(self, auto_schema, direction):
+        default = auto_schema._map_serializer_field(self.target, direction, bypass_extensions=True);
+
+        if self.target.help_text is not None:
+            default['example'] = self.target.help_text
+            default.pop('description', None)
+
+        return default

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -366,10 +366,10 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                 description=(
                     "Filtre les bâtiments grâce à une bounding box.<br/>\n"
                     "Le format est nw_lat,nw_lng,se_lat,se_lng avec :<br/>\n"
-                        "• nw_lat : latitude du point Nord Ouest<br/>\n"
-                        "• nw_lng : longitude du point Nord Ouest<br/>\n"
-                        "• se_lat : latitude du point Sud Est<br/>\n"
-                        "• se_lng : longitude du point Sud Est<br/>\n"
+                    "• nw_lat : latitude du point Nord Ouest<br/>\n"
+                    "• nw_lng : longitude du point Nord Ouest<br/>\n"
+                    "• se_lat : latitude du point Sud Est<br/>\n"
+                    "• se_lng : longitude du point Sud Est<br/>\n"
                 ),
                 examples=[
                     OpenApiExample(
@@ -390,14 +390,14 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                     "canceledConstructionProject",
                 ],
                 description=(
-                        "Filtre les bâtiments par statut.<br/><br/>\n"
-                        "• constructed : Bâtiment construit<br/>\n"
-                        "• ongoingChange : En cours de modification<br/>\n"
-                        "• notUsable : Non utilisable (ex : une ruine)<br/>\n"
-                        "• demolished : Démoli<br/>\n"
-                        "Statuts réservés aux instructeurs d’autorisation du droit des sols.<br/><br/>\n"
-                        "• constructionProject : Bâtiment en projet<br/>\n"
-                        "• canceledConstructionProject : Projet de bâtiment annulé"
+                    "Filtre les bâtiments par statut.<br/><br/>\n"
+                    "• constructed : Bâtiment construit<br/>\n"
+                    "• ongoingChange : En cours de modification<br/>\n"
+                    "• notUsable : Non utilisable (ex : une ruine)<br/>\n"
+                    "• demolished : Démoli<br/>\n"
+                    "Statuts réservés aux instructeurs d’autorisation du droit des sols.<br/><br/>\n"
+                    "• constructionProject : Bâtiment en projet<br/>\n"
+                    "• canceledConstructionProject : Projet de bâtiment annulé"
                 ),
                 examples=[
                     OpenApiExample(
@@ -1054,7 +1054,7 @@ def get_stats(request):
             description=(
                 "Date et heure à partir de laquelle les modifications sont retournées.<br/>\n"
                 "Au format ISO 8601.<br/><br/>\n"
-                "Si un \"+\" est présent dans la date, il doit être encodé en %2B.<br/>\n"
+                'Si un "+" est présent dans la date, il doit être encodé en %2B.<br/>\n'
                 "2024-04-02 15:29:44.26+01 => 2024-04-02 15:29:44.26%2B01<br/><br/>\n"
                 "Seules les dates après le 1er avril 2024 sont acceptées.<br/>\n"
                 "Une date inférieure reviendrait à télécharger l'intégralité de la base de données.<br/>\n"

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -11,11 +11,12 @@ from django.http import Http404
 from django.http import HttpResponse
 from django.http import JsonResponse
 from django.utils.dateparse import parse_datetime
-from drf_spectacular.extensions import OpenApiAuthenticationExtension, OpenApiSerializerFieldExtension
+from drf_spectacular.extensions import OpenApiAuthenticationExtension
 from drf_spectacular.openapi import OpenApiExample
 from drf_spectacular.openapi import OpenApiParameter
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema, OpenApiResponse
+from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiResponse
 from psycopg2 import sql
 from rest_framework import mixins
 from rest_framework import status
@@ -54,6 +55,7 @@ from batid.services.vector_tiles import tile_sql
 from batid.services.vector_tiles import url_params_to_tile
 from batid.utils.constants import ADS_GROUP_NAME
 
+
 class IsSuperUser(BasePermission):
     def has_permission(self, request, view):
         return bool(request.user and request.user.is_superuser)
@@ -66,114 +68,109 @@ class RNBLoggingMixin(LoggingMixin):
 
 class BuildingGuessView(RNBLoggingMixin, APIView):
     @extend_schema(
-        tags=['Bâtiment'],
-        operation_id='guess_building',
-        summary='Identification de bâtiment',
+        tags=["Bâtiment"],
+        operation_id="guess_building",
+        summary="Identification de bâtiment",
         description=(
-                "Ce endpoint permet de trouver un ou plusieurs bâtiments correspondant à une série de critères. "
-                "Il permet d'accueillir des données imprécises et tente de les combiner pour fournir le meilleur résultat."
+            "Ce endpoint permet de trouver un ou plusieurs bâtiments correspondant à une série de critères. "
+            "Il permet d'accueillir des données imprécises et tente de les combiner pour fournir le meilleur résultat."
         ),
         auth=[],
         parameters=[
             OpenApiParameter(
-                name='address',
+                name="address",
                 description=(
-                        "Utilise les geocoders de la Base Adresse Nationale et d'Open Street Map pour tenter "
-                        "de géolocaliser l'adresse indiquée."
+                    "Utilise les geocoders de la Base Adresse Nationale et d'Open Street Map pour tenter "
+                    "de géolocaliser l'adresse indiquée."
                 ),
                 required=False,
                 type=str,
                 examples=[
                     OpenApiExample(
-                        "Exemple d'adresse",
-                        value="10 rue de la paix, Mérignac"
+                        "Exemple d'adresse", value="10 rue de la paix, Mérignac"
                     )
-                ]
+                ],
             ),
             OpenApiParameter(
-                name='name',
+                name="name",
                 description=(
-                        "Utilise un geocoder Open Street Map pour tenter de géolocaliser le lieu donné."
+                    "Utilise un geocoder Open Street Map pour tenter de géolocaliser le lieu donné."
                 ),
                 required=False,
                 type=str,
                 examples=[
-                    OpenApiExample(
-                        "Exemple de lieu",
-                        value="Notre Dame de Paris"
-                    )
-                ]
+                    OpenApiExample("Exemple de lieu", value="Notre Dame de Paris")
+                ],
             ),
             OpenApiParameter(
-                name='point',
+                name="point",
                 description=(
-                        "Favorise les bâtiments en fonction de leur position par rapport au point indiqué "
-                        "(latitude et longitude séparées par une virgule)."
+                    "Favorise les bâtiments en fonction de leur position par rapport au point indiqué "
+                    "(latitude et longitude séparées par une virgule)."
                 ),
                 required=False,
                 type=str,
                 examples=[
                     OpenApiExample(
                         "Exemple de point",
-                        value="44.84114313595151,-0.5705289444867035"
+                        value="44.84114313595151,-0.5705289444867035",
                     )
-                ]
+                ],
             ),
             OpenApiParameter(
-                name='page',
+                name="page",
                 description="Pagination des résultats de recherche.",
                 required=False,
                 type=int,
                 default=1,
-                examples=[
-                    OpenApiExample(
-                        "Page par défaut",
-                        value=1
-                    )
-                ]
-            )
+                examples=[OpenApiExample("Page par défaut", value=1)],
+            ),
         ],
         responses={
-            200: OpenApiResponse(response=GuessBuildingSerializer(many=True), examples=[OpenApiExample(name='Exemple', value={
-                "rnb_id": "QBAAG16VCJWA",
-                "score": 0.753986390,
-                "status": "constructed",
-                "point": {
-                    "type": "Point",
-                    "coordinates": [
-                        3.584410393780201,
-                        49.52799819019749,
-                    ],
-                },
-                "addresses": [
-                    {
-                        "id": "02191_0020_00003",
-                        "source": "bdnb",
-                        "street_number": "3",
-                        "street_rep": "",
-                        "street_name": "de l'eglise",
-                        "street_type": "rue",
-                        "city_name": "Chivy-lès-Étouvelles",
-                        "city_zipcode": "02000",
-                        "city_insee_code": "02191",
-                    }
+            200: OpenApiResponse(
+                response=GuessBuildingSerializer(many=True),
+                examples=[
+                    OpenApiExample(
+                        name="Exemple",
+                        value={
+                            "rnb_id": "QBAAG16VCJWA",
+                            "score": 0.753986390,
+                            "status": "constructed",
+                            "point": {
+                                "type": "Point",
+                                "coordinates": [
+                                    3.584410393780201,
+                                    49.52799819019749,
+                                ],
+                            },
+                            "addresses": [
+                                {
+                                    "id": "02191_0020_00003",
+                                    "source": "bdnb",
+                                    "street_number": "3",
+                                    "street_rep": "",
+                                    "street_name": "de l'eglise",
+                                    "street_type": "rue",
+                                    "city_name": "Chivy-lès-Étouvelles",
+                                    "city_zipcode": "02000",
+                                    "city_insee_code": "02191",
+                                }
+                            ],
+                            "ext_ids": [
+                                {
+                                    "id": "bdnb-bc-3B85-TYM9-FDSX",
+                                    "source": "bdnb",
+                                    "created_at": "2023-12-07T13:20:58.310444+00:00",
+                                    "source_version": "2023_01",
+                                }
+                            ],
+                        },
+                    )
                 ],
-                "ext_ids": [
-                    {
-                        "id": "bdnb-bc-3B85-TYM9-FDSX",
-                        "source": "bdnb",
-                        "created_at": "2023-12-07T13:20:58.310444+00:00",
-                        "source_version": "2023_01",
-                    }
-                ],
-            })]),
-            400: {
-                'description': 'Requête invalide'
-            },
-            404: {
-                'description': 'Bâtiment non trouvé'
-            }
-        }
+            ),
+            400: {"description": "Requête invalide"},
+            404: {"description": "Bâtiment non trouvé"},
+        },
     )
     def get(self, request, *args, **kwargs):
         search = BuildingGuess()
@@ -353,12 +350,12 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
         return qs
 
     @extend_schema(
-        tags=['Bâtiment'],
-        operation_id='list_buildings',
-        summary='Listing de bâtiments',
+        tags=["Bâtiment"],
+        operation_id="list_buildings",
+        summary="Listing de bâtiments",
         description=(
-                "Ce endpoint permet de récupérer une liste paginée de bâtiments. "
-                "Des filtres, notamment par code INSEE de la commune, sont disponibles."
+            "Ce endpoint permet de récupérer une liste paginée de bâtiments. "
+            "Des filtres, notamment par code INSEE de la commune, sont disponibles."
         ),
         auth=[],
         parameters=[
@@ -435,81 +432,83 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
             ),
         ],
         responses={
-            200: OpenApiResponse(response=BuildingSerializer(many=True), examples=[
-                OpenApiExample(name='Exemple', value=[
-                    {
-                        "rnb_id": "QBAAG16VCJWA",
-                        "status": "constructed",
-                        "point": {
-                            "type": "Point",
-                            "coordinates": [
-                                3.584410393780201,
-                                49.52799819019749
-                            ]
-                        },
-                        "addresses": [
+            200: OpenApiResponse(
+                response=BuildingSerializer(many=True),
+                examples=[
+                    OpenApiExample(
+                        name="Exemple",
+                        value=[
                             {
-                                "id": "02191_0020_00003",
-                                "source": "bdnb",
-                                "street_number": "3",
-                                "street_rep": "",
-                                "street_name": "de l'eglise",
-                                "street_type": "rue",
-                                "city_name": "Chivy-lès-Étouvelles",
-                                "city_zipcode": "02000",
-                                "city_insee_code": "02191"
-                            }
+                                "rnb_id": "QBAAG16VCJWA",
+                                "status": "constructed",
+                                "point": {
+                                    "type": "Point",
+                                    "coordinates": [
+                                        3.584410393780201,
+                                        49.52799819019749,
+                                    ],
+                                },
+                                "addresses": [
+                                    {
+                                        "id": "02191_0020_00003",
+                                        "source": "bdnb",
+                                        "street_number": "3",
+                                        "street_rep": "",
+                                        "street_name": "de l'eglise",
+                                        "street_type": "rue",
+                                        "city_name": "Chivy-lès-Étouvelles",
+                                        "city_zipcode": "02000",
+                                        "city_insee_code": "02191",
+                                    }
+                                ],
+                                "ext_ids": [
+                                    {
+                                        "id": "bdnb-bc-3B85-TYM9-FDSX",
+                                        "source": "bdnb",
+                                        "created_at": "2023-12-07T13:20:58.310444+00:00",
+                                        "source_version": "2023_01",
+                                    }
+                                ],
+                            },
+                            {
+                                "rnb_id": "FXFJZNZYGTED",
+                                "status": "constructed",
+                                "point": {
+                                    "type": "Point",
+                                    "coordinates": [
+                                        5.775791408470412,
+                                        45.256939624268206,
+                                    ],
+                                },
+                                "addresses": [
+                                    {
+                                        "id": "02191_0020_00005",
+                                        "source": "bdnb",
+                                        "street_number": "5",
+                                        "street_rep": "",
+                                        "street_name": "de l'eglise",
+                                        "street_type": "rue",
+                                        "city_name": "Chivy-lès-Étouvelles",
+                                        "city_zipcode": "02000",
+                                        "city_insee_code": "02191",
+                                    }
+                                ],
+                                "ext_ids": [
+                                    {
+                                        "id": "bdnb-bc-3B86-TYM9-FRTS",
+                                        "source": "bdnb",
+                                        "created_at": "2023-12-07T13:25:58.310444+00:00",
+                                        "source_version": "2023_01",
+                                    }
+                                ],
+                            },
                         ],
-                        "ext_ids": [
-                            {
-                                "id": "bdnb-bc-3B85-TYM9-FDSX",
-                                "source": "bdnb",
-                                "created_at": "2023-12-07T13:20:58.310444+00:00",
-                                "source_version": "2023_01"
-                            }
-                        ]
-                    },
-                    {
-                        "rnb_id": "FXFJZNZYGTED",
-                        "status": "constructed",
-                        "point": {
-                            "type": "Point",
-                            "coordinates": [
-                                5.775791408470412,
-                                45.256939624268206
-                            ]
-                        },
-                        "addresses": [
-                            {
-                                "id": "02191_0020_00005",
-                                "source": "bdnb",
-                                "street_number": "5",
-                                "street_rep": "",
-                                "street_name": "de l'eglise",
-                                "street_type": "rue",
-                                "city_name": "Chivy-lès-Étouvelles",
-                                "city_zipcode": "02000",
-                                "city_insee_code": "02191"
-                            }
-                        ],
-                        "ext_ids": [
-                            {
-                                "id": "bdnb-bc-3B86-TYM9-FRTS",
-                                "source": "bdnb",
-                                "created_at": "2023-12-07T13:25:58.310444+00:00",
-                                "source_version": "2023_01"
-                            }
-                        ]
-                    }
-                ])
-            ]),
-            400: {
-                'description': 'Requête invalide'
-            },
-            404: {
-                'description': 'Bâtiment non trouvé'
-            }
-        }
+                    )
+                ],
+            ),
+            400: {"description": "Requête invalide"},
+            404: {"description": "Bâtiment non trouvé"},
+        },
     )
     def list(self, request, *args, **kwargs):
         """
@@ -518,62 +517,63 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
         return super().list(request, *args, **kwargs)
 
     @extend_schema(
-        tags=['Bâtiment'],
-        operation_id='get_building',
-        summary='Consultation d\'un bâtiment',
+        tags=["Bâtiment"],
+        operation_id="get_building",
+        summary="Consultation d'un bâtiment",
         description=(
-                "Ce endpoint permet de récupérer l'ensemble des attributs d'un bâtiment à partir de son identifiant RNB. "
-                "L'API renvoie les informations détaillées telles que l'ID du bâtiment, le statut, la géolocalisation, "
-                "les adresses associées et les identifiants externes."
+            "Ce endpoint permet de récupérer l'ensemble des attributs d'un bâtiment à partir de son identifiant RNB. "
+            "L'API renvoie les informations détaillées telles que l'ID du bâtiment, le statut, la géolocalisation, "
+            "les adresses associées et les identifiants externes."
         ),
         auth=[],
         parameters=[
             OpenApiParameter(
-                name='rnb_id',
-                description='Identifiant RNB du bâtiment',
+                name="rnb_id",
+                description="Identifiant RNB du bâtiment",
                 required=True,
-                type=str
+                type=str,
             )
         ],
         responses={
-            200: OpenApiResponse(response=BuildingSerializer, examples=[
-                OpenApiExample(name='Exemple', value={
-                    "rnb_id": "QBAAG16VCJWA",
-                    "status": "constructed",
-                    "point": {
-                        "type": "Point",
-                        "coordinates": [
-                            3.584410393780201,
-                            49.52799819019749
-                        ]
-                    },
-                    "addresses": [
-                        {
-                            "id": "02191_0020_00003",
-                            "source": "bdnb",
-                            "street_number": "3",
-                            "street_rep": "",
-                            "street_name": "de l'eglise",
-                            "street_type": "rue",
-                            "city_name": "Chivy-lès-Étouvelles",
-                            "city_zipcode": "02000",
-                            "city_insee_code": "02191"
-                        }
-                    ],
-                    "ext_ids": [
-                        {
-                            "id": "bdnb-bc-3B85-TYM9-FDSX",
-                            "source": "bdnb",
-                            "created_at": "2023-12-07T13:20:58.310444+00:00",
-                            "source_version": "2023_01"
-                        }
-                    ]
-                })
-            ]),
-            404: {
-                'description': 'Bâtiment non trouvé'
-            }
-        }
+            200: OpenApiResponse(
+                response=BuildingSerializer,
+                examples=[
+                    OpenApiExample(
+                        name="Exemple",
+                        value={
+                            "rnb_id": "QBAAG16VCJWA",
+                            "status": "constructed",
+                            "point": {
+                                "type": "Point",
+                                "coordinates": [3.584410393780201, 49.52799819019749],
+                            },
+                            "addresses": [
+                                {
+                                    "id": "02191_0020_00003",
+                                    "source": "bdnb",
+                                    "street_number": "3",
+                                    "street_rep": "",
+                                    "street_name": "de l'eglise",
+                                    "street_type": "rue",
+                                    "city_name": "Chivy-lès-Étouvelles",
+                                    "city_zipcode": "02000",
+                                    "city_insee_code": "02191",
+                                }
+                            ],
+                            "ext_ids": [
+                                {
+                                    "id": "bdnb-bc-3B85-TYM9-FDSX",
+                                    "source": "bdnb",
+                                    "created_at": "2023-12-07T13:20:58.310444+00:00",
+                                    "source_version": "2023_01",
+                                }
+                            ],
+                        },
+                    )
+                ],
+            ),
+            404: {"description": "Bâtiment non trouvé"},
+        },
     )
     def retrieve(self, request, *args, **kwargs):
         """
@@ -648,33 +648,132 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
         return search.get_queryset()
 
     @extend_schema(
-        tags=['ADS'],
-        operation_id='list_ads',
-        summary='Liste et recherche d\'ADS',
+        tags=["ADS"],
+        operation_id="list_ads",
+        summary="Liste et recherche d'ADS",
         description=(
-                "Cette API permet de lister et de rechercher des ADS (Autorisation de Droit de Sol). "
-                "Les requêtes doivent être authentifiées en utilisant un token. "
-                "Les filtres de recherche peuvent être passés en tant que paramètres d'URL."
+            "Cette API permet de lister et de rechercher des ADS (Autorisation de Droit de Sol). "
+            "Les requêtes doivent être authentifiées en utilisant un token. "
+            "Les filtres de recherche peuvent être passés en tant que paramètres d'URL."
         ),
         parameters=[
-            OpenApiParameter(name='q', description='Recherche parmi les n° de dossiers (file_number).', required=False, type=str),
-            OpenApiParameter(name='since', description='Récupère tous les dossiers décidés depuis cette date (AAAA-MM-DD).', required=False, type=str),
+            OpenApiParameter(
+                name="q",
+                description="Recherche parmi les n° de dossiers (file_number).",
+                required=False,
+                type=str,
+            ),
+            OpenApiParameter(
+                name="since",
+                description="Récupère tous les dossiers décidés depuis cette date (AAAA-MM-DD).",
+                required=False,
+                type=str,
+            ),
         ],
         responses={
-            200: OpenApiResponse(response=ADSSerializer, examples=[
-                OpenApiExample(name='Exemple', value={
-                    "count": 3,
-                    "next": None,
-                    "previous": None,
-                    "results": [
-                        {
+            200: OpenApiResponse(
+                response=ADSSerializer,
+                examples=[
+                    OpenApiExample(
+                        name="Exemple",
+                        value={
+                            "count": 3,
+                            "next": None,
+                            "previous": None,
+                            "results": [
+                                {
+                                    "file_number": "TEST03818519U9999",
+                                    "decided_at": "2023-06-01",
+                                    "buildings_operations": [
+                                        {
+                                            "rnb_id": "A1B2C3A1B2C3",
+                                            "shape": None,
+                                            "operation": "build",
+                                        },
+                                        {
+                                            "rnb_id": None,
+                                            "shape": {
+                                                "type": "Point",
+                                                "coordinates": [
+                                                    5.722961565015281,
+                                                    45.1851103238598,
+                                                ],
+                                            },
+                                            "operation": "demolish",
+                                        },
+                                        {
+                                            "rnb_id": "1M2N3O1M2N3O",
+                                            "shape": {
+                                                "type": "Point",
+                                                "coordinates": [
+                                                    5.723006573148693,
+                                                    45.1851402293713,
+                                                ],
+                                            },
+                                            "operation": "demolish",
+                                        },
+                                    ],
+                                },
+                                {
+                                    "file_number": "PC3807123200WW",
+                                    "decided_at": "2023-05-01",
+                                    "buildings_operations": [
+                                        {
+                                            "rnb_id": "FXFJZNZYGTED",
+                                            "shape": None,
+                                            "operation": "build",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "file_number": "PC384712301337",
+                                    "decided_at": "2023-02-22",
+                                    "buildings_operations": [
+                                        {
+                                            "rnb_id": "RXNOSN2DUCLG",
+                                            "geometry": {
+                                                "type": "Point",
+                                                "coordinates": [
+                                                    5.775791408470412,
+                                                    45.256939624268206,
+                                                ],
+                                            },
+                                            "operation": "modify",
+                                        }
+                                    ],
+                                },
+                            ],
+                        },
+                    )
+                ],
+            )
+        },
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
+
+    @extend_schema(
+        tags=["ADS"],
+        operation_id="get_ads",
+        summary="Obtenir une ADS",
+        description=(
+            "Cette API permet de récupérer une ADS (Autorisation de Droit de Sol). "
+            "Les requêtes doivent être authentifiées en utilisant un token. "
+        ),
+        responses={
+            200: OpenApiResponse(
+                response=ADSSerializer,
+                examples=[
+                    OpenApiExample(
+                        name="Exemple",
+                        value={
                             "file_number": "TEST03818519U9999",
                             "decided_at": "2023-06-01",
                             "buildings_operations": [
                                 {
                                     "rnb_id": "A1B2C3A1B2C3",
                                     "shape": None,
-                                    "operation": "build"
+                                    "operation": "build",
                                 },
                                 {
                                     "rnb_id": None,
@@ -682,10 +781,10 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                                         "type": "Point",
                                         "coordinates": [
                                             5.722961565015281,
-                                            45.1851103238598
-                                        ]
+                                            45.1851103238598,
+                                        ],
                                     },
-                                    "operation": "demolish"
+                                    "operation": "demolish",
                                 },
                                 {
                                     "rnb_id": "1M2N3O1M2N3O",
@@ -693,193 +792,123 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                                         "type": "Point",
                                         "coordinates": [
                                             5.723006573148693,
-                                            45.1851402293713
-                                        ]
+                                            45.1851402293713,
+                                        ],
                                     },
-                                    "operation": "demolish"
-                                }
-                            ]
+                                    "operation": "demolish",
+                                },
+                            ],
                         },
-                        {
-                            "file_number": "PC3807123200WW",
-                            "decided_at": "2023-05-01",
-                            "buildings_operations": [
-                                {
-                                    "rnb_id": "FXFJZNZYGTED",
-                                    "shape": None,
-                                    "operation": "build"
-                                }
-                            ]
-                        },
-                        {
-                            "file_number": "PC384712301337",
-                            "decided_at": "2023-02-22",
-                            "buildings_operations": [
-                                {
-                                    "rnb_id": "RXNOSN2DUCLG",
-                                    "geometry": {
-                                        "type": "Point",
-                                        "coordinates": [
-                                            5.775791408470412,
-                                            45.256939624268206
-                                        ]
-                                    },
-                                    "operation": "modify"
-                                }
-                            ]
-                        },
-                    ]
-                })
-            ])
-        }
-    )
-    def list(self, request, *args, **kwargs):
-        return super().list(request, *args, **kwargs)
-
-    @extend_schema(
-        tags=['ADS'],
-        operation_id='get_ads',
-        summary='Obtenir une ADS',
-        description=(
-                "Cette API permet de récupérer une ADS (Autorisation de Droit de Sol). "
-                "Les requêtes doivent être authentifiées en utilisant un token. "
-        ),
-        responses={
-            200: OpenApiResponse(response=ADSSerializer, examples=[
-                OpenApiExample(name='Exemple', value={
-                    "file_number": "TEST03818519U9999",
-                    "decided_at": "2023-06-01",
-                    "buildings_operations": [
-                        {
-                            "rnb_id": "A1B2C3A1B2C3",
-                            "shape": None,
-                            "operation": "build"
-                        },
-                        {
-                            "rnb_id": None,
-                            "shape": {
-                                "type": "Point",
-                                "coordinates": [
-                                    5.722961565015281,
-                                    45.1851103238598
-                                ]
-                            },
-                            "operation": "demolish"
-                        },
-                        {
-                            "rnb_id": "1M2N3O1M2N3O",
-                            "shape": {
-                                "type": "Point",
-                                "coordinates": [
-                                    5.723006573148693,
-                                    45.1851402293713
-                                ]
-                            },
-                            "operation": "demolish"
-                        }
-                    ]
-                })
-            ])
-        }
+                    )
+                ],
+            )
+        },
     )
     def retrieve(self, request, *args, **kwargs):
         return super().retrieve(request, *args, **kwargs)
 
     @extend_schema(
-        tags=['ADS'],
-        operation_id='create_ads',
-        summary='Création d\'une ADS',
+        tags=["ADS"],
+        operation_id="create_ads",
+        summary="Création d'une ADS",
         description=(
-                "Ce endpoint permet de créer une Autorisation du Droit des Sols (ADS) dans le RNB. "
-                "L'API ADS est réservée aux communes et requiert une authentification par token."
+            "Ce endpoint permet de créer une Autorisation du Droit des Sols (ADS) dans le RNB. "
+            "L'API ADS est réservée aux communes et requiert une authentification par token."
         ),
         request=ADSSerializer,
         responses={
-            201: OpenApiResponse(response=ADSSerializer, examples=[
-                OpenApiExample(name='Exemple', value={
-                    "file_number": "PCXXXXXXXXXX",
-                    "decided_at": "2019-03-18",
-                    "buildings_operations": [
-                        {
-                            "operation": "demolish",
-                            "rnb_id": "ABCD1234WXYZ",
-                            "shape": None
+            201: OpenApiResponse(
+                response=ADSSerializer,
+                examples=[
+                    OpenApiExample(
+                        name="Exemple",
+                        value={
+                            "file_number": "PCXXXXXXXXXX",
+                            "decided_at": "2019-03-18",
+                            "buildings_operations": [
+                                {
+                                    "operation": "demolish",
+                                    "rnb_id": "ABCD1234WXYZ",
+                                    "shape": None,
+                                },
+                                {
+                                    "operation": "build",
+                                    "rnb_id": None,
+                                    "shape": {
+                                        "type": "Point",
+                                        "coordinates": [
+                                            2.3552747458487002,
+                                            48.86958288638419,
+                                        ],
+                                    },
+                                },
+                            ],
                         },
-                        {
-                            "operation": "build",
-                            "rnb_id": None,
-                            "shape": {
-                                "type": "Point",
-                                "coordinates": [2.3552747458487002, 48.86958288638419]
-                            }
-                        }
-                    ]
-                })
-            ]),
-            400: {
-                'description': 'Requête invalide'
-            }
-        }
+                    )
+                ],
+            ),
+            400: {"description": "Requête invalide"},
+        },
     )
     def create(self, request, *args, **kwargs):
         return super().create(request, *args, **kwargs)
 
-
     @extend_schema(
-        tags=['ADS'],
-        operation_id='update_ads',
-        summary='Modification d\'une ADS',
+        tags=["ADS"],
+        operation_id="update_ads",
+        summary="Modification d'une ADS",
         description=(
-                "Ce endpoint permet de modifier une Autorisation du Droit des Sols (ADS) existante dans le RNB. "
-                "L'API ADS est réservée aux communes et requiert une authentification par token."
+            "Ce endpoint permet de modifier une Autorisation du Droit des Sols (ADS) existante dans le RNB. "
+            "L'API ADS est réservée aux communes et requiert une authentification par token."
         ),
         request=ADSSerializer,
         responses={
-            200: OpenApiResponse(response=ADSSerializer, examples=[
-                OpenApiExample(name='Exemple', value={
-                    "file_number": "PCXXXXXXXXXX",
-                    "decided_at": "2019-03-10",
-                    "buildings_operations": [
-                        {
-                            "operation": "demolish",
-                            "rnb_id": "7865HG43PLS9",
-                            "shape": None
+            200: OpenApiResponse(
+                response=ADSSerializer,
+                examples=[
+                    OpenApiExample(
+                        name="Exemple",
+                        value={
+                            "file_number": "PCXXXXXXXXXX",
+                            "decided_at": "2019-03-10",
+                            "buildings_operations": [
+                                {
+                                    "operation": "demolish",
+                                    "rnb_id": "7865HG43PLS9",
+                                    "shape": None,
+                                },
+                                {
+                                    "operation": "build",
+                                    "rnb_id": None,
+                                    "shape": {
+                                        "type": "Point",
+                                        "coordinates": [
+                                            2.3552747458487002,
+                                            48.86958288638419,
+                                        ],
+                                    },
+                                },
+                            ],
                         },
-                        {
-                            "operation": "build",
-                            "rnb_id": None,
-                            "shape": {
-                                "type": "Point",
-                                "coordinates": [2.3552747458487002, 48.86958288638419]
-                            }
-                        }
-                    ]
-                })
-            ]),
-            400: {
-                'description': 'Requête invalide'
-            },
-            404: {
-                'description': 'ADS non trouvée'
-            }
-        }
+                    )
+                ],
+            ),
+            400: {"description": "Requête invalide"},
+            404: {"description": "ADS non trouvée"},
+        },
     )
     def update(self, request, *args, **kwargs):
         return super().update(request, *args, **kwargs)
 
     @extend_schema(
-        tags=['ADS'],
-        operation_id='delete_ads',
-        summary='Suppression d\'une ADS',
-        description='Ce endpoint permet de supprimer une Autorisation du Droit des Sols (ADS) existante dans le RNB.',
+        tags=["ADS"],
+        operation_id="delete_ads",
+        summary="Suppression d'une ADS",
+        description="Ce endpoint permet de supprimer une Autorisation du Droit des Sols (ADS) existante dans le RNB.",
         responses={
-            204: {
-                'description': 'ADS supprimée avec succès'
-            },
-            404: {
-                'description': 'ADS non trouvée'
-            }
-        }
+            204: {"description": "ADS supprimée avec succès"},
+            404: {"description": "ADS non trouvée"},
+        },
     )
     def destroy(self, request, *args, **kwargs):
         return super().destroy(request, *args, **kwargs)
@@ -887,44 +916,40 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
 
 class GetVectorTileView(APIView):
     @extend_schema(
-        tags=['Tile'],
-        operation_id='get_vector_tiles',
-        summary='Obtenir des tuiles vectorielles',
+        tags=["Tile"],
+        operation_id="get_vector_tiles",
+        summary="Obtenir des tuiles vectorielles",
         description=(
-                "Cette API fournit des tuiles vectorielles au format PBF permettant d'intégrer les bâtiments "
-                "du Référentiel National des Bâtiments (RNB) dans une cartographie. Chaque tuile contient des points "
-                "représentant des bâtiments avec un attribut 'rnb_id'. Les tuiles sont utilisables avec un niveau de zoom "
-                "minimal de 16 et peuvent être intégrées dans des outils comme QGIS ou des sites web."
+            "Cette API fournit des tuiles vectorielles au format PBF permettant d'intégrer les bâtiments "
+            "du Référentiel National des Bâtiments (RNB) dans une cartographie. Chaque tuile contient des points "
+            "représentant des bâtiments avec un attribut 'rnb_id'. Les tuiles sont utilisables avec un niveau de zoom "
+            "minimal de 16 et peuvent être intégrées dans des outils comme QGIS ou des sites web."
         ),
         auth=[],
         parameters=[
             OpenApiParameter(
-                name='x',
-                description='Coordonnée X de la tuile',
+                name="x",
+                description="Coordonnée X de la tuile",
                 required=True,
-                type=int
+                type=int,
             ),
             OpenApiParameter(
-                name='y',
-                description='Coordonnée Y de la tuile',
+                name="y",
+                description="Coordonnée Y de la tuile",
                 required=True,
-                type=int
+                type=int,
             ),
             OpenApiParameter(
-                name='z',
-                description='Niveau de zoom de la tuile',
+                name="z",
+                description="Niveau de zoom de la tuile",
                 required=True,
-                type=int
+                type=int,
             ),
         ],
         responses={
-            200: {
-                'description': 'Fichier PBF contenant les tuiles vectorielles'
-            },
-            400: {
-                'description': 'Requête invalide'
-            }
-        }
+            200: {"description": "Fichier PBF contenant les tuiles vectorielles"},
+            400: {"description": "Requête invalide"},
+        },
     )
     def get(request, x, y, z):
         # Check the request zoom level
@@ -1000,9 +1025,9 @@ def get_stats(request):
 
 
 @extend_schema(
-    tags=['Bâtiment'],
-    operation_id='get_building_diff',
-    summary='Obtenir les dernières modifications',
+    tags=["Bâtiment"],
+    operation_id="get_building_diff",
+    summary="Obtenir les dernières modifications",
     description="""
         Filtre les modifications apportées au RNB ayant eu lieu strictement après un datetime.
         Les données sont retournées au format CSV.
@@ -1037,20 +1062,26 @@ def get_stats(request):
         ),
     ],
     responses={
-        200: OpenApiResponse(response=OpenApiTypes.STR, examples=[
-            OpenApiExample(name='Exemple', value=(
-                    "action,rnb_id,status,sys_period,point,shape,addresses_id,ext_ids\n"
-                    "create,QBAAG16VCJWA,constructed,\"[2024-04-02,)\",POINT(3.584410393780201 49.52799819019749),,02191_0020_00003,\n"
-                    "update,QBAAG16VCJWA,constructed,\"[2024-04-03,)\",POINT(3.584410393780201 49.52799819019749),,02191_0020_00003,\n"
-            ))
-        ]),
+        200: OpenApiResponse(
+            response=OpenApiTypes.STR,
+            examples=[
+                OpenApiExample(
+                    name="Exemple",
+                    value=(
+                        "action,rnb_id,status,sys_period,point,shape,addresses_id,ext_ids\n"
+                        'create,QBAAG16VCJWA,constructed,"[2024-04-02,)",POINT(3.584410393780201 49.52799819019749),,02191_0020_00003,\n'
+                        'update,QBAAG16VCJWA,constructed,"[2024-04-03,)",POINT(3.584410393780201 49.52799819019749),,02191_0020_00003,\n'
+                    ),
+                )
+            ],
+        ),
         400: {
-            'description': "Le paramètre 'since' est manquant ou incorrect",
+            "description": "Le paramètre 'since' est manquant ou incorrect",
         },
         404: {
-            'description': "Aucune modification trouvée pour les critères donnés",
-        }
-    }
+            "description": "Aucune modification trouvée pour les critères donnés",
+        },
+    },
 )
 @api_view(["GET"])
 def get_diff(request):
@@ -1266,21 +1297,21 @@ class AdsTokenView(APIView):
 
 
 class TokenScheme(OpenApiAuthenticationExtension):
-    target_class = 'rest_framework.authentication.TokenAuthentication'
-    name = 'RNBTokenAuth'
+    target_class = "rest_framework.authentication.TokenAuthentication"
+    name = "RNBTokenAuth"
     priority = 1
 
     def get_security_definition(self, auto_schema):
         return {
-            'type': 'apiKey',
-            'in': 'header',
-            'name': 'Authorization',
-            'description': 'Toutes les requêtes liées aux ADS doivent faire l’objet d’une authentification. '
-                           'Pour vous identifier, utilisez le token fourni par l’équipe du RNB. '
-                           'Pour faire une demande de token, renseignez ce formulaire.\n\n'
-                           'Ajoutez une clé `Authorization` aux headers HTTP de chacune de vos requêtes. '
-                           'La valeur doit être votre token préfixé de la chaîne “Token”. '
-                           'Un espace sépare “Token” et votre token.\n\n'
-                           'Exemple:\n\n'
-                           '`Authorization: Token 9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b`'
+            "type": "apiKey",
+            "in": "header",
+            "name": "Authorization",
+            "description": "Toutes les requêtes liées aux ADS doivent faire l’objet d’une authentification. "
+            "Pour vous identifier, utilisez le token fourni par l’équipe du RNB. "
+            "Pour faire une demande de token, renseignez ce formulaire.\n\n"
+            "Ajoutez une clé `Authorization` aux headers HTTP de chacune de vos requêtes. "
+            "La valeur doit être votre token préfixé de la chaîne “Token”. "
+            "Un espace sépare “Token” et votre token.\n\n"
+            "Exemple:\n\n"
+            "`Authorization: Token 9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b`",
         }

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -11,12 +11,11 @@ from django.http import Http404
 from django.http import HttpResponse
 from django.http import JsonResponse
 from django.utils.dateparse import parse_datetime
-from drf_spectacular.extensions import OpenApiAuthenticationExtension
+from drf_spectacular.extensions import OpenApiAuthenticationExtension, OpenApiSerializerFieldExtension
 from drf_spectacular.openapi import OpenApiExample
 from drf_spectacular.openapi import OpenApiParameter
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema
-from drf_spectacular.utils import OpenApiResponse
+from drf_spectacular.utils import extend_schema, OpenApiResponse
 from psycopg2 import sql
 from rest_framework import mixins
 from rest_framework import status
@@ -55,7 +54,6 @@ from batid.services.vector_tiles import tile_sql
 from batid.services.vector_tiles import url_params_to_tile
 from batid.utils.constants import ADS_GROUP_NAME
 
-
 class IsSuperUser(BasePermission):
     def has_permission(self, request, view):
         return bool(request.user and request.user.is_superuser)
@@ -68,109 +66,114 @@ class RNBLoggingMixin(LoggingMixin):
 
 class BuildingGuessView(RNBLoggingMixin, APIView):
     @extend_schema(
-        tags=["Bâtiment"],
-        operation_id="guess_building",
-        summary="Identification de bâtiment",
+        tags=['Bâtiment'],
+        operation_id='guess_building',
+        summary='Identification de bâtiment',
         description=(
-            "Ce endpoint permet de trouver un ou plusieurs bâtiments correspondant à une série de critères. "
-            "Il permet d'accueillir des données imprécises et tente de les combiner pour fournir le meilleur résultat."
+                "Ce endpoint permet de trouver un ou plusieurs bâtiments correspondant à une série de critères. "
+                "Il permet d'accueillir des données imprécises et tente de les combiner pour fournir le meilleur résultat."
         ),
         auth=[],
         parameters=[
             OpenApiParameter(
-                name="address",
+                name='address',
                 description=(
-                    "Utilise les geocoders de la Base Adresse Nationale et d'Open Street Map pour tenter "
-                    "de géolocaliser l'adresse indiquée."
+                        "Utilise les geocoders de la Base Adresse Nationale et d'Open Street Map pour tenter "
+                        "de géolocaliser l'adresse indiquée."
                 ),
                 required=False,
                 type=str,
                 examples=[
                     OpenApiExample(
-                        "Exemple d'adresse", value="10 rue de la paix, Mérignac"
+                        "Exemple d'adresse",
+                        value="10 rue de la paix, Mérignac"
                     )
-                ],
+                ]
             ),
             OpenApiParameter(
-                name="name",
+                name='name',
                 description=(
-                    "Utilise un geocoder Open Street Map pour tenter de géolocaliser le lieu donné."
+                        "Utilise un geocoder Open Street Map pour tenter de géolocaliser le lieu donné."
                 ),
                 required=False,
                 type=str,
                 examples=[
-                    OpenApiExample("Exemple de lieu", value="Notre Dame de Paris")
-                ],
+                    OpenApiExample(
+                        "Exemple de lieu",
+                        value="Notre Dame de Paris"
+                    )
+                ]
             ),
             OpenApiParameter(
-                name="point",
+                name='point',
                 description=(
-                    "Favorise les bâtiments en fonction de leur position par rapport au point indiqué "
-                    "(latitude et longitude séparées par une virgule)."
+                        "Favorise les bâtiments en fonction de leur position par rapport au point indiqué "
+                        "(latitude et longitude séparées par une virgule)."
                 ),
                 required=False,
                 type=str,
                 examples=[
                     OpenApiExample(
                         "Exemple de point",
-                        value="44.84114313595151,-0.5705289444867035",
+                        value="44.84114313595151,-0.5705289444867035"
                     )
-                ],
+                ]
             ),
             OpenApiParameter(
-                name="page",
+                name='page',
                 description="Pagination des résultats de recherche.",
                 required=False,
                 type=int,
                 default=1,
-                examples=[OpenApiExample("Page par défaut", value=1)],
-            ),
-        ],
-        responses={
-            200: OpenApiResponse(
-                response=GuessBuildingSerializer(many=True),
                 examples=[
                     OpenApiExample(
-                        name="Exemple",
-                        value={
-                            "rnb_id": "QBAAG16VCJWA",
-                            "score": 0.753986390,
-                            "status": "constructed",
-                            "point": {
-                                "type": "Point",
-                                "coordinates": [
-                                    3.584410393780201,
-                                    49.52799819019749,
-                                ],
-                            },
-                            "addresses": [
-                                {
-                                    "id": "02191_0020_00003",
-                                    "source": "bdnb",
-                                    "street_number": "3",
-                                    "street_rep": "",
-                                    "street_name": "de l'eglise",
-                                    "street_type": "rue",
-                                    "city_name": "Chivy-lès-Étouvelles",
-                                    "city_zipcode": "02000",
-                                    "city_insee_code": "02191",
-                                }
-                            ],
-                            "ext_ids": [
-                                {
-                                    "id": "bdnb-bc-3B85-TYM9-FDSX",
-                                    "source": "bdnb",
-                                    "created_at": "2023-12-07T13:20:58.310444+00:00",
-                                    "source_version": "2023_01",
-                                }
-                            ],
-                        },
+                        "Page par défaut",
+                        value=1
                     )
+                ]
+            )
+        ],
+        responses={
+            200: OpenApiResponse(response=GuessBuildingSerializer(many=True), examples=[OpenApiExample(name='Exemple', value={
+                "rnb_id": "QBAAG16VCJWA",
+                "score": 0.753986390,
+                "status": "constructed",
+                "point": {
+                    "type": "Point",
+                    "coordinates": [
+                        3.584410393780201,
+                        49.52799819019749,
+                    ],
+                },
+                "addresses": [
+                    {
+                        "id": "02191_0020_00003",
+                        "source": "bdnb",
+                        "street_number": "3",
+                        "street_rep": "",
+                        "street_name": "de l'eglise",
+                        "street_type": "rue",
+                        "city_name": "Chivy-lès-Étouvelles",
+                        "city_zipcode": "02000",
+                        "city_insee_code": "02191",
+                    }
                 ],
-            ),
-            400: {"description": "Requête invalide"},
-            404: {"description": "Bâtiment non trouvé"},
-        },
+                "ext_ids": [
+                    {
+                        "id": "bdnb-bc-3B85-TYM9-FDSX",
+                        "source": "bdnb",
+                        "created_at": "2023-12-07T13:20:58.310444+00:00",
+                        "source_version": "2023_01",
+                    }
+                ],
+            })]),
+            400: {
+                'description': 'Requête invalide'
+            },
+            404: {
+                'description': 'Bâtiment non trouvé'
+            }
+        }
     )
     def get(self, request, *args, **kwargs):
         search = BuildingGuess()
@@ -350,12 +353,12 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
         return qs
 
     @extend_schema(
-        tags=["Bâtiment"],
-        operation_id="list_buildings",
-        summary="Listing de bâtiments",
+        tags=['Bâtiment'],
+        operation_id='list_buildings',
+        summary='Listing de bâtiments',
         description=(
-            "Ce endpoint permet de récupérer une liste paginée de bâtiments. "
-            "Des filtres, notamment par code INSEE de la commune, sont disponibles."
+                "Ce endpoint permet de récupérer une liste paginée de bâtiments. "
+                "Des filtres, notamment par code INSEE de la commune, sont disponibles."
         ),
         auth=[],
         parameters=[
@@ -432,83 +435,81 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
             ),
         ],
         responses={
-            200: OpenApiResponse(
-                response=BuildingSerializer(many=True),
-                examples=[
-                    OpenApiExample(
-                        name="Exemple",
-                        value=[
+            200: OpenApiResponse(response=BuildingSerializer(many=True), examples=[
+                OpenApiExample(name='Exemple', value=[
+                    {
+                        "rnb_id": "QBAAG16VCJWA",
+                        "status": "constructed",
+                        "point": {
+                            "type": "Point",
+                            "coordinates": [
+                                3.584410393780201,
+                                49.52799819019749
+                            ]
+                        },
+                        "addresses": [
                             {
-                                "rnb_id": "QBAAG16VCJWA",
-                                "status": "constructed",
-                                "point": {
-                                    "type": "Point",
-                                    "coordinates": [
-                                        3.584410393780201,
-                                        49.52799819019749,
-                                    ],
-                                },
-                                "addresses": [
-                                    {
-                                        "id": "02191_0020_00003",
-                                        "source": "bdnb",
-                                        "street_number": "3",
-                                        "street_rep": "",
-                                        "street_name": "de l'eglise",
-                                        "street_type": "rue",
-                                        "city_name": "Chivy-lès-Étouvelles",
-                                        "city_zipcode": "02000",
-                                        "city_insee_code": "02191",
-                                    }
-                                ],
-                                "ext_ids": [
-                                    {
-                                        "id": "bdnb-bc-3B85-TYM9-FDSX",
-                                        "source": "bdnb",
-                                        "created_at": "2023-12-07T13:20:58.310444+00:00",
-                                        "source_version": "2023_01",
-                                    }
-                                ],
-                            },
-                            {
-                                "rnb_id": "FXFJZNZYGTED",
-                                "status": "constructed",
-                                "point": {
-                                    "type": "Point",
-                                    "coordinates": [
-                                        5.775791408470412,
-                                        45.256939624268206,
-                                    ],
-                                },
-                                "addresses": [
-                                    {
-                                        "id": "02191_0020_00005",
-                                        "source": "bdnb",
-                                        "street_number": "5",
-                                        "street_rep": "",
-                                        "street_name": "de l'eglise",
-                                        "street_type": "rue",
-                                        "city_name": "Chivy-lès-Étouvelles",
-                                        "city_zipcode": "02000",
-                                        "city_insee_code": "02191",
-                                    }
-                                ],
-                                "ext_ids": [
-                                    {
-                                        "id": "bdnb-bc-3B86-TYM9-FRTS",
-                                        "source": "bdnb",
-                                        "created_at": "2023-12-07T13:25:58.310444+00:00",
-                                        "source_version": "2023_01",
-                                    }
-                                ],
-                            },
+                                "id": "02191_0020_00003",
+                                "source": "bdnb",
+                                "street_number": "3",
+                                "street_rep": "",
+                                "street_name": "de l'eglise",
+                                "street_type": "rue",
+                                "city_name": "Chivy-lès-Étouvelles",
+                                "city_zipcode": "02000",
+                                "city_insee_code": "02191"
+                            }
                         ],
-                    )
-                ],
-            ),
-            400: {"description": "Requête invalide"},
-            404: {"description": "Bâtiment non trouvé"},
-        },
+                        "ext_ids": [
+                            {
+                                "id": "bdnb-bc-3B85-TYM9-FDSX",
+                                "source": "bdnb",
+                                "created_at": "2023-12-07T13:20:58.310444+00:00",
+                                "source_version": "2023_01"
+                            }
+                        ]
+                    },
+                    {
+                        "rnb_id": "FXFJZNZYGTED",
+                        "status": "constructed",
+                        "point": {
+                            "type": "Point",
+                            "coordinates": [
+                                5.775791408470412,
+                                45.256939624268206
+                            ]
+                        },
+                        "addresses": [
+                            {
+                                "id": "02191_0020_00005",
+                                "source": "bdnb",
+                                "street_number": "5",
+                                "street_rep": "",
+                                "street_name": "de l'eglise",
+                                "street_type": "rue",
+                                "city_name": "Chivy-lès-Étouvelles",
+                                "city_zipcode": "02000",
+                                "city_insee_code": "02191"
+                            }
+                        ],
+                        "ext_ids": [
+                            {
+                                "id": "bdnb-bc-3B86-TYM9-FRTS",
+                                "source": "bdnb",
+                                "created_at": "2023-12-07T13:25:58.310444+00:00",
+                                "source_version": "2023_01"
+                            }
+                        ]
+                    }
+                ])
+            ]),
+            400: {
+                'description': 'Requête invalide'
+            },
+            404: {
+                'description': 'Bâtiment non trouvé'
+            }
+        }
     )
     def list(self, request, *args, **kwargs):
         """
@@ -517,63 +518,63 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
         return super().list(request, *args, **kwargs)
 
     @extend_schema(
-        tags=["Bâtiment"],
-        operation_id="get_building",
-        summary="Consultation d'un bâtiment",
+        tags=['Bâtiment'],
+        operation_id='get_building',
+        summary='Consultation d\'un bâtiment',
         description=(
-            "Ce endpoint permet de récupérer l'ensemble des attributs d'un bâtiment à partir de son identifiant RNB. "
-            "L'API renvoie les informations détaillées telles que l'ID du bâtiment, le statut, la géolocalisation, "
-            "les adresses associées et les identifiants externes."
+                "Ce endpoint permet de récupérer l'ensemble des attributs d'un bâtiment à partir de son identifiant RNB. "
+                "L'API renvoie les informations détaillées telles que l'ID du bâtiment, le statut, la géolocalisation, "
+                "les adresses associées et les identifiants externes."
         ),
         auth=[],
         parameters=[
             OpenApiParameter(
-                name="rnb_id",
-                description="Identifiant RNB du bâtiment",
+                name='rnb_id',
+                description='Identifiant RNB du bâtiment',
                 required=True,
                 type=str,
+                location=OpenApiParameter.PATH
             )
         ],
         responses={
-            200: OpenApiResponse(
-                response=BuildingSerializer,
-                examples=[
-                    OpenApiExample(
-                        name="Exemple",
-                        value={
-                            "rnb_id": "QBAAG16VCJWA",
-                            "status": "constructed",
-                            "point": {
-                                "type": "Point",
-                                "coordinates": [3.584410393780201, 49.52799819019749],
-                            },
-                            "addresses": [
-                                {
-                                    "id": "02191_0020_00003",
-                                    "source": "bdnb",
-                                    "street_number": "3",
-                                    "street_rep": "",
-                                    "street_name": "de l'eglise",
-                                    "street_type": "rue",
-                                    "city_name": "Chivy-lès-Étouvelles",
-                                    "city_zipcode": "02000",
-                                    "city_insee_code": "02191",
-                                }
-                            ],
-                            "ext_ids": [
-                                {
-                                    "id": "bdnb-bc-3B85-TYM9-FDSX",
-                                    "source": "bdnb",
-                                    "created_at": "2023-12-07T13:20:58.310444+00:00",
-                                    "source_version": "2023_01",
-                                }
-                            ],
-                        },
-                    )
-                ],
-            ),
-            404: {"description": "Bâtiment non trouvé"},
-        },
+            200: OpenApiResponse(response=BuildingSerializer, examples=[
+                OpenApiExample(name='Exemple', value={
+                    "rnb_id": "QBAAG16VCJWA",
+                    "status": "constructed",
+                    "point": {
+                        "type": "Point",
+                        "coordinates": [
+                            3.584410393780201,
+                            49.52799819019749
+                        ]
+                    },
+                    "addresses": [
+                        {
+                            "id": "02191_0020_00003",
+                            "source": "bdnb",
+                            "street_number": "3",
+                            "street_rep": "",
+                            "street_name": "de l'eglise",
+                            "street_type": "rue",
+                            "city_name": "Chivy-lès-Étouvelles",
+                            "city_zipcode": "02000",
+                            "city_insee_code": "02191"
+                        }
+                    ],
+                    "ext_ids": [
+                        {
+                            "id": "bdnb-bc-3B85-TYM9-FDSX",
+                            "source": "bdnb",
+                            "created_at": "2023-12-07T13:20:58.310444+00:00",
+                            "source_version": "2023_01"
+                        }
+                    ]
+                })
+            ]),
+            404: {
+                'description': 'Bâtiment non trouvé'
+            }
+        }
     )
     def retrieve(self, request, *args, **kwargs):
         """
@@ -648,132 +649,33 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
         return search.get_queryset()
 
     @extend_schema(
-        tags=["ADS"],
-        operation_id="list_ads",
-        summary="Liste et recherche d'ADS",
+        tags=['ADS'],
+        operation_id='list_ads',
+        summary='Liste et recherche d\'ADS',
         description=(
-            "Cette API permet de lister et de rechercher des ADS (Autorisation de Droit de Sol). "
-            "Les requêtes doivent être authentifiées en utilisant un token. "
-            "Les filtres de recherche peuvent être passés en tant que paramètres d'URL."
+                "Cette API permet de lister et de rechercher des ADS (Autorisation de Droit de Sol). "
+                "Les requêtes doivent être authentifiées en utilisant un token. "
+                "Les filtres de recherche peuvent être passés en tant que paramètres d'URL."
         ),
         parameters=[
-            OpenApiParameter(
-                name="q",
-                description="Recherche parmi les n° de dossiers (file_number).",
-                required=False,
-                type=str,
-            ),
-            OpenApiParameter(
-                name="since",
-                description="Récupère tous les dossiers décidés depuis cette date (AAAA-MM-DD).",
-                required=False,
-                type=str,
-            ),
+            OpenApiParameter(name='q', description='Recherche parmi les n° de dossiers (file_number).', required=False, type=str),
+            OpenApiParameter(name='since', description='Récupère tous les dossiers décidés depuis cette date (AAAA-MM-DD).', required=False, type=str),
         ],
         responses={
-            200: OpenApiResponse(
-                response=ADSSerializer,
-                examples=[
-                    OpenApiExample(
-                        name="Exemple",
-                        value={
-                            "count": 3,
-                            "next": None,
-                            "previous": None,
-                            "results": [
-                                {
-                                    "file_number": "TEST03818519U9999",
-                                    "decided_at": "2023-06-01",
-                                    "buildings_operations": [
-                                        {
-                                            "rnb_id": "A1B2C3A1B2C3",
-                                            "shape": None,
-                                            "operation": "build",
-                                        },
-                                        {
-                                            "rnb_id": None,
-                                            "shape": {
-                                                "type": "Point",
-                                                "coordinates": [
-                                                    5.722961565015281,
-                                                    45.1851103238598,
-                                                ],
-                                            },
-                                            "operation": "demolish",
-                                        },
-                                        {
-                                            "rnb_id": "1M2N3O1M2N3O",
-                                            "shape": {
-                                                "type": "Point",
-                                                "coordinates": [
-                                                    5.723006573148693,
-                                                    45.1851402293713,
-                                                ],
-                                            },
-                                            "operation": "demolish",
-                                        },
-                                    ],
-                                },
-                                {
-                                    "file_number": "PC3807123200WW",
-                                    "decided_at": "2023-05-01",
-                                    "buildings_operations": [
-                                        {
-                                            "rnb_id": "FXFJZNZYGTED",
-                                            "shape": None,
-                                            "operation": "build",
-                                        }
-                                    ],
-                                },
-                                {
-                                    "file_number": "PC384712301337",
-                                    "decided_at": "2023-02-22",
-                                    "buildings_operations": [
-                                        {
-                                            "rnb_id": "RXNOSN2DUCLG",
-                                            "geometry": {
-                                                "type": "Point",
-                                                "coordinates": [
-                                                    5.775791408470412,
-                                                    45.256939624268206,
-                                                ],
-                                            },
-                                            "operation": "modify",
-                                        }
-                                    ],
-                                },
-                            ],
-                        },
-                    )
-                ],
-            )
-        },
-    )
-    def list(self, request, *args, **kwargs):
-        return super().list(request, *args, **kwargs)
-
-    @extend_schema(
-        tags=["ADS"],
-        operation_id="get_ads",
-        summary="Obtenir une ADS",
-        description=(
-            "Cette API permet de récupérer une ADS (Autorisation de Droit de Sol). "
-            "Les requêtes doivent être authentifiées en utilisant un token. "
-        ),
-        responses={
-            200: OpenApiResponse(
-                response=ADSSerializer,
-                examples=[
-                    OpenApiExample(
-                        name="Exemple",
-                        value={
+            200: OpenApiResponse(response=ADSSerializer, examples=[
+                OpenApiExample(name='Exemple', value={
+                    "count": 3,
+                    "next": None,
+                    "previous": None,
+                    "results": [
+                        {
                             "file_number": "TEST03818519U9999",
                             "decided_at": "2023-06-01",
                             "buildings_operations": [
                                 {
                                     "rnb_id": "A1B2C3A1B2C3",
                                     "shape": None,
-                                    "operation": "build",
+                                    "operation": "build"
                                 },
                                 {
                                     "rnb_id": None,
@@ -781,10 +683,10 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                                         "type": "Point",
                                         "coordinates": [
                                             5.722961565015281,
-                                            45.1851103238598,
-                                        ],
+                                            45.1851103238598
+                                        ]
                                     },
-                                    "operation": "demolish",
+                                    "operation": "demolish"
                                 },
                                 {
                                     "rnb_id": "1M2N3O1M2N3O",
@@ -792,123 +694,202 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                                         "type": "Point",
                                         "coordinates": [
                                             5.723006573148693,
-                                            45.1851402293713,
-                                        ],
+                                            45.1851402293713
+                                        ]
                                     },
-                                    "operation": "demolish",
-                                },
-                            ],
+                                    "operation": "demolish"
+                                }
+                            ]
                         },
-                    )
-                ],
-            )
-        },
+                        {
+                            "file_number": "PC3807123200WW",
+                            "decided_at": "2023-05-01",
+                            "buildings_operations": [
+                                {
+                                    "rnb_id": "FXFJZNZYGTED",
+                                    "shape": None,
+                                    "operation": "build"
+                                }
+                            ]
+                        },
+                        {
+                            "file_number": "PC384712301337",
+                            "decided_at": "2023-02-22",
+                            "buildings_operations": [
+                                {
+                                    "rnb_id": "RXNOSN2DUCLG",
+                                    "geometry": {
+                                        "type": "Point",
+                                        "coordinates": [
+                                            5.775791408470412,
+                                            45.256939624268206
+                                        ]
+                                    },
+                                    "operation": "modify"
+                                }
+                            ]
+                        },
+                    ]
+                })
+            ])
+        }
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
+
+    @extend_schema(
+        tags=['ADS'],
+        operation_id='get_ads',
+        summary='Obtenir une ADS',
+        description=(
+                "Cette API permet de récupérer une ADS (Autorisation de Droit de Sol). "
+                "Les requêtes doivent être authentifiées en utilisant un token. "
+        ),
+        parameters=[
+            OpenApiParameter(
+                name='file_number',
+                 description='Récupération par n° de dossier (file_number).',
+                 required=True,
+                 type=str,
+                 location=OpenApiParameter.PATH
+            ),
+        ],
+        responses={
+            200: OpenApiResponse(response=ADSSerializer, examples=[
+                OpenApiExample(name='Exemple', value={
+                    "file_number": "TEST03818519U9999",
+                    "decided_at": "2023-06-01",
+                    "buildings_operations": [
+                        {
+                            "rnb_id": "A1B2C3A1B2C3",
+                            "shape": None,
+                            "operation": "build"
+                        },
+                        {
+                            "rnb_id": None,
+                            "shape": {
+                                "type": "Point",
+                                "coordinates": [
+                                    5.722961565015281,
+                                    45.1851103238598
+                                ]
+                            },
+                            "operation": "demolish"
+                        },
+                        {
+                            "rnb_id": "1M2N3O1M2N3O",
+                            "shape": {
+                                "type": "Point",
+                                "coordinates": [
+                                    5.723006573148693,
+                                    45.1851402293713
+                                ]
+                            },
+                            "operation": "demolish"
+                        }
+                    ]
+                })
+            ])
+        }
     )
     def retrieve(self, request, *args, **kwargs):
         return super().retrieve(request, *args, **kwargs)
 
     @extend_schema(
-        tags=["ADS"],
-        operation_id="create_ads",
-        summary="Création d'une ADS",
+        tags=['ADS'],
+        operation_id='create_ads',
+        summary='Création d\'une ADS',
         description=(
-            "Ce endpoint permet de créer une Autorisation du Droit des Sols (ADS) dans le RNB. "
-            "L'API ADS est réservée aux communes et requiert une authentification par token."
+                "Ce endpoint permet de créer une Autorisation du Droit des Sols (ADS) dans le RNB. "
+                "L'API ADS est réservée aux communes et requiert une authentification par token."
         ),
         request=ADSSerializer,
         responses={
-            201: OpenApiResponse(
-                response=ADSSerializer,
-                examples=[
-                    OpenApiExample(
-                        name="Exemple",
-                        value={
-                            "file_number": "PCXXXXXXXXXX",
-                            "decided_at": "2019-03-18",
-                            "buildings_operations": [
-                                {
-                                    "operation": "demolish",
-                                    "rnb_id": "ABCD1234WXYZ",
-                                    "shape": None,
-                                },
-                                {
-                                    "operation": "build",
-                                    "rnb_id": None,
-                                    "shape": {
-                                        "type": "Point",
-                                        "coordinates": [
-                                            2.3552747458487002,
-                                            48.86958288638419,
-                                        ],
-                                    },
-                                },
-                            ],
+            201: OpenApiResponse(response=ADSSerializer, examples=[
+                OpenApiExample(name='Exemple', value={
+                    "file_number": "PCXXXXXXXXXX",
+                    "decided_at": "2019-03-18",
+                    "buildings_operations": [
+                        {
+                            "operation": "demolish",
+                            "rnb_id": "ABCD1234WXYZ",
+                            "shape": None
                         },
-                    )
-                ],
-            ),
-            400: {"description": "Requête invalide"},
-        },
+                        {
+                            "operation": "build",
+                            "rnb_id": None,
+                            "shape": {
+                                "type": "Point",
+                                "coordinates": [2.3552747458487002, 48.86958288638419]
+                            }
+                        }
+                    ]
+                })
+            ]),
+            400: {
+                'description': 'Requête invalide'
+            }
+        }
     )
     def create(self, request, *args, **kwargs):
         return super().create(request, *args, **kwargs)
 
+
     @extend_schema(
-        tags=["ADS"],
-        operation_id="update_ads",
-        summary="Modification d'une ADS",
+        tags=['ADS'],
+        operation_id='update_ads',
+        summary='Modification d\'une ADS',
         description=(
-            "Ce endpoint permet de modifier une Autorisation du Droit des Sols (ADS) existante dans le RNB. "
-            "L'API ADS est réservée aux communes et requiert une authentification par token."
+                "Ce endpoint permet de modifier une Autorisation du Droit des Sols (ADS) existante dans le RNB. "
+                "L'API ADS est réservée aux communes et requiert une authentification par token."
         ),
         request=ADSSerializer,
         responses={
-            200: OpenApiResponse(
-                response=ADSSerializer,
-                examples=[
-                    OpenApiExample(
-                        name="Exemple",
-                        value={
-                            "file_number": "PCXXXXXXXXXX",
-                            "decided_at": "2019-03-10",
-                            "buildings_operations": [
-                                {
-                                    "operation": "demolish",
-                                    "rnb_id": "7865HG43PLS9",
-                                    "shape": None,
-                                },
-                                {
-                                    "operation": "build",
-                                    "rnb_id": None,
-                                    "shape": {
-                                        "type": "Point",
-                                        "coordinates": [
-                                            2.3552747458487002,
-                                            48.86958288638419,
-                                        ],
-                                    },
-                                },
-                            ],
+            200: OpenApiResponse(response=ADSSerializer, examples=[
+                OpenApiExample(name='Exemple', value={
+                    "file_number": "PCXXXXXXXXXX",
+                    "decided_at": "2019-03-10",
+                    "buildings_operations": [
+                        {
+                            "operation": "demolish",
+                            "rnb_id": "7865HG43PLS9",
+                            "shape": None
                         },
-                    )
-                ],
-            ),
-            400: {"description": "Requête invalide"},
-            404: {"description": "ADS non trouvée"},
-        },
+                        {
+                            "operation": "build",
+                            "rnb_id": None,
+                            "shape": {
+                                "type": "Point",
+                                "coordinates": [2.3552747458487002, 48.86958288638419]
+                            }
+                        }
+                    ]
+                })
+            ]),
+            400: {
+                'description': 'Requête invalide'
+            },
+            404: {
+                'description': 'ADS non trouvée'
+            }
+        }
     )
     def update(self, request, *args, **kwargs):
         return super().update(request, *args, **kwargs)
 
     @extend_schema(
-        tags=["ADS"],
-        operation_id="delete_ads",
-        summary="Suppression d'une ADS",
-        description="Ce endpoint permet de supprimer une Autorisation du Droit des Sols (ADS) existante dans le RNB.",
+        tags=['ADS'],
+        operation_id='delete_ads',
+        summary='Suppression d\'une ADS',
+        description='Ce endpoint permet de supprimer une Autorisation du Droit des Sols (ADS) existante dans le RNB.',
         responses={
-            204: {"description": "ADS supprimée avec succès"},
-            404: {"description": "ADS non trouvée"},
-        },
+            204: {
+                'description': 'ADS supprimée avec succès'
+            },
+            404: {
+                'description': 'ADS non trouvée'
+            }
+        }
     )
     def destroy(self, request, *args, **kwargs):
         return super().destroy(request, *args, **kwargs)
@@ -916,42 +897,50 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
 
 class GetVectorTileView(APIView):
     @extend_schema(
-        tags=["Tile"],
-        operation_id="get_vector_tiles",
-        summary="Obtenir des tuiles vectorielles",
+        tags=['Tile'],
+        operation_id='get_vector_tile',
+        summary='Obtenir une tuile vectorielle',
         description=(
-            "Cette API fournit des tuiles vectorielles au format PBF permettant d'intégrer les bâtiments "
-            "du Référentiel National des Bâtiments (RNB) dans une cartographie. Chaque tuile contient des points "
-            "représentant des bâtiments avec un attribut 'rnb_id'. Les tuiles sont utilisables avec un niveau de zoom "
-            "minimal de 16 et peuvent être intégrées dans des outils comme QGIS ou des sites web."
+                "Cette API fournit des tuiles vectorielles au format PBF permettant d'intégrer les bâtiments "
+                "du Référentiel National des Bâtiments (RNB) dans une cartographie. Chaque tuile contient des points "
+                "représentant des bâtiments avec un attribut 'rnb_id'. Les tuiles sont utilisables avec un niveau de zoom "
+                "minimal de 16 et peuvent être intégrées dans des outils comme QGIS ou des sites web."
         ),
         auth=[],
         parameters=[
             OpenApiParameter(
-                name="x",
-                description="Coordonnée X de la tuile",
+                name='x',
+                description='Coordonnée X de la tuile',
                 required=True,
                 type=int,
+                location=OpenApiParameter.PATH
             ),
             OpenApiParameter(
-                name="y",
-                description="Coordonnée Y de la tuile",
+                name='y',
+                description='Coordonnée Y de la tuile',
                 required=True,
                 type=int,
+                location=OpenApiParameter.PATH
             ),
             OpenApiParameter(
-                name="z",
-                description="Niveau de zoom de la tuile",
+                name='z',
+                description='Niveau de zoom de la tuile',
                 required=True,
                 type=int,
+                location=OpenApiParameter.PATH
             ),
         ],
         responses={
-            200: {"description": "Fichier PBF contenant les tuiles vectorielles"},
-            400: {"description": "Requête invalide"},
-        },
+            200: OpenApiResponse(
+                response=OpenApiTypes.BINARY,
+                description='Fichier PBF contenant les tuiles vectorielles'
+            ),
+            400: {
+                'description': 'Requête invalide'
+            }
+        }
     )
-    def get(request, x, y, z):
+    def get(self, request, x, y, z):
         # Check the request zoom level
         if int(z) >= 16:
             tile_dict = url_params_to_tile(x, y, z)
@@ -1025,9 +1014,9 @@ def get_stats(request):
 
 
 @extend_schema(
-    tags=["Bâtiment"],
-    operation_id="get_building_diff",
-    summary="Obtenir les dernières modifications",
+    tags=['Bâtiment'],
+    operation_id='get_building_diff',
+    summary='Obtenir les dernières modifications',
     description="""
         Filtre les modifications apportées au RNB ayant eu lieu strictement après un datetime.
         Les données sont retournées au format CSV.
@@ -1062,26 +1051,20 @@ def get_stats(request):
         ),
     ],
     responses={
-        200: OpenApiResponse(
-            response=OpenApiTypes.STR,
-            examples=[
-                OpenApiExample(
-                    name="Exemple",
-                    value=(
-                        "action,rnb_id,status,sys_period,point,shape,addresses_id,ext_ids\n"
-                        'create,QBAAG16VCJWA,constructed,"[2024-04-02,)",POINT(3.584410393780201 49.52799819019749),,02191_0020_00003,\n'
-                        'update,QBAAG16VCJWA,constructed,"[2024-04-03,)",POINT(3.584410393780201 49.52799819019749),,02191_0020_00003,\n'
-                    ),
-                )
-            ],
-        ),
+        200: OpenApiResponse(response=OpenApiTypes.STR, examples=[
+            OpenApiExample(name='Exemple', value=(
+                    "action,rnb_id,status,sys_period,point,shape,addresses_id,ext_ids\n"
+                    "create,QBAAG16VCJWA,constructed,\"[2024-04-02,)\",POINT(3.584410393780201 49.52799819019749),,02191_0020_00003,\n"
+                    "update,QBAAG16VCJWA,constructed,\"[2024-04-03,)\",POINT(3.584410393780201 49.52799819019749),,02191_0020_00003,\n"
+            ))
+        ]),
         400: {
-            "description": "Le paramètre 'since' est manquant ou incorrect",
+            'description': "Le paramètre 'since' est manquant ou incorrect",
         },
         404: {
-            "description": "Aucune modification trouvée pour les critères donnés",
-        },
-    },
+            'description': "Aucune modification trouvée pour les critères donnés",
+        }
+    }
 )
 @api_view(["GET"])
 def get_diff(request):
@@ -1297,21 +1280,21 @@ class AdsTokenView(APIView):
 
 
 class TokenScheme(OpenApiAuthenticationExtension):
-    target_class = "rest_framework.authentication.TokenAuthentication"
-    name = "RNBTokenAuth"
+    target_class = 'rest_framework.authentication.TokenAuthentication'
+    name = 'RNBTokenAuth'
     priority = 1
 
     def get_security_definition(self, auto_schema):
         return {
-            "type": "apiKey",
-            "in": "header",
-            "name": "Authorization",
-            "description": "Toutes les requêtes liées aux ADS doivent faire l’objet d’une authentification. "
-            "Pour vous identifier, utilisez le token fourni par l’équipe du RNB. "
-            "Pour faire une demande de token, renseignez ce formulaire.\n\n"
-            "Ajoutez une clé `Authorization` aux headers HTTP de chacune de vos requêtes. "
-            "La valeur doit être votre token préfixé de la chaîne “Token”. "
-            "Un espace sépare “Token” et votre token.\n\n"
-            "Exemple:\n\n"
-            "`Authorization: Token 9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b`",
+            'type': 'apiKey',
+            'in': 'header',
+            'name': 'Authorization',
+            'description': 'Toutes les requêtes liées aux ADS doivent faire l’objet d’une authentification. '
+                           'Pour vous identifier, utilisez le token fourni par l’équipe du RNB. '
+                           'Pour faire une demande de token, renseignez ce formulaire.\n\n'
+                           'Ajoutez une clé `Authorization` aux headers HTTP de chacune de vos requêtes. '
+                           'La valeur doit être votre token préfixé de la chaîne “Token”. '
+                           'Un espace sépare “Token” et votre token.\n\n'
+                           'Exemple:\n\n'
+                           '`Authorization: Token 9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b`'
         }

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -11,11 +11,12 @@ from django.http import Http404
 from django.http import HttpResponse
 from django.http import JsonResponse
 from django.utils.dateparse import parse_datetime
-from drf_spectacular.extensions import OpenApiAuthenticationExtension, OpenApiSerializerFieldExtension
+from drf_spectacular.extensions import OpenApiAuthenticationExtension
 from drf_spectacular.openapi import OpenApiExample
 from drf_spectacular.openapi import OpenApiParameter
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema, OpenApiResponse
+from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiResponse
 from psycopg2 import sql
 from rest_framework import mixins
 from rest_framework import status
@@ -54,6 +55,7 @@ from batid.services.vector_tiles import tile_sql
 from batid.services.vector_tiles import url_params_to_tile
 from batid.utils.constants import ADS_GROUP_NAME
 
+
 class IsSuperUser(BasePermission):
     def has_permission(self, request, view):
         return bool(request.user and request.user.is_superuser)
@@ -66,114 +68,109 @@ class RNBLoggingMixin(LoggingMixin):
 
 class BuildingGuessView(RNBLoggingMixin, APIView):
     @extend_schema(
-        tags=['Bâtiment'],
-        operation_id='guess_building',
-        summary='Identification de bâtiment',
+        tags=["Bâtiment"],
+        operation_id="guess_building",
+        summary="Identification de bâtiment",
         description=(
-                "Ce endpoint permet de trouver un ou plusieurs bâtiments correspondant à une série de critères. "
-                "Il permet d'accueillir des données imprécises et tente de les combiner pour fournir le meilleur résultat."
+            "Ce endpoint permet de trouver un ou plusieurs bâtiments correspondant à une série de critères. "
+            "Il permet d'accueillir des données imprécises et tente de les combiner pour fournir le meilleur résultat."
         ),
         auth=[],
         parameters=[
             OpenApiParameter(
-                name='address',
+                name="address",
                 description=(
-                        "Utilise les geocoders de la Base Adresse Nationale et d'Open Street Map pour tenter "
-                        "de géolocaliser l'adresse indiquée."
+                    "Utilise les geocoders de la Base Adresse Nationale et d'Open Street Map pour tenter "
+                    "de géolocaliser l'adresse indiquée."
                 ),
                 required=False,
                 type=str,
                 examples=[
                     OpenApiExample(
-                        "Exemple d'adresse",
-                        value="10 rue de la paix, Mérignac"
+                        "Exemple d'adresse", value="10 rue de la paix, Mérignac"
                     )
-                ]
+                ],
             ),
             OpenApiParameter(
-                name='name',
+                name="name",
                 description=(
-                        "Utilise un geocoder Open Street Map pour tenter de géolocaliser le lieu donné."
+                    "Utilise un geocoder Open Street Map pour tenter de géolocaliser le lieu donné."
                 ),
                 required=False,
                 type=str,
                 examples=[
-                    OpenApiExample(
-                        "Exemple de lieu",
-                        value="Notre Dame de Paris"
-                    )
-                ]
+                    OpenApiExample("Exemple de lieu", value="Notre Dame de Paris")
+                ],
             ),
             OpenApiParameter(
-                name='point',
+                name="point",
                 description=(
-                        "Favorise les bâtiments en fonction de leur position par rapport au point indiqué "
-                        "(latitude et longitude séparées par une virgule)."
+                    "Favorise les bâtiments en fonction de leur position par rapport au point indiqué "
+                    "(latitude et longitude séparées par une virgule)."
                 ),
                 required=False,
                 type=str,
                 examples=[
                     OpenApiExample(
                         "Exemple de point",
-                        value="44.84114313595151,-0.5705289444867035"
+                        value="44.84114313595151,-0.5705289444867035",
                     )
-                ]
+                ],
             ),
             OpenApiParameter(
-                name='page',
+                name="page",
                 description="Pagination des résultats de recherche.",
                 required=False,
                 type=int,
                 default=1,
-                examples=[
-                    OpenApiExample(
-                        "Page par défaut",
-                        value=1
-                    )
-                ]
-            )
+                examples=[OpenApiExample("Page par défaut", value=1)],
+            ),
         ],
         responses={
-            200: OpenApiResponse(response=GuessBuildingSerializer(many=True), examples=[OpenApiExample(name='Exemple', value={
-                "rnb_id": "QBAAG16VCJWA",
-                "score": 0.753986390,
-                "status": "constructed",
-                "point": {
-                    "type": "Point",
-                    "coordinates": [
-                        3.584410393780201,
-                        49.52799819019749,
-                    ],
-                },
-                "addresses": [
-                    {
-                        "id": "02191_0020_00003",
-                        "source": "bdnb",
-                        "street_number": "3",
-                        "street_rep": "",
-                        "street_name": "de l'eglise",
-                        "street_type": "rue",
-                        "city_name": "Chivy-lès-Étouvelles",
-                        "city_zipcode": "02000",
-                        "city_insee_code": "02191",
-                    }
+            200: OpenApiResponse(
+                response=GuessBuildingSerializer(many=True),
+                examples=[
+                    OpenApiExample(
+                        name="Exemple",
+                        value={
+                            "rnb_id": "QBAAG16VCJWA",
+                            "score": 0.753986390,
+                            "status": "constructed",
+                            "point": {
+                                "type": "Point",
+                                "coordinates": [
+                                    3.584410393780201,
+                                    49.52799819019749,
+                                ],
+                            },
+                            "addresses": [
+                                {
+                                    "id": "02191_0020_00003",
+                                    "source": "bdnb",
+                                    "street_number": "3",
+                                    "street_rep": "",
+                                    "street_name": "de l'eglise",
+                                    "street_type": "rue",
+                                    "city_name": "Chivy-lès-Étouvelles",
+                                    "city_zipcode": "02000",
+                                    "city_insee_code": "02191",
+                                }
+                            ],
+                            "ext_ids": [
+                                {
+                                    "id": "bdnb-bc-3B85-TYM9-FDSX",
+                                    "source": "bdnb",
+                                    "created_at": "2023-12-07T13:20:58.310444+00:00",
+                                    "source_version": "2023_01",
+                                }
+                            ],
+                        },
+                    )
                 ],
-                "ext_ids": [
-                    {
-                        "id": "bdnb-bc-3B85-TYM9-FDSX",
-                        "source": "bdnb",
-                        "created_at": "2023-12-07T13:20:58.310444+00:00",
-                        "source_version": "2023_01",
-                    }
-                ],
-            })]),
-            400: {
-                'description': 'Requête invalide'
-            },
-            404: {
-                'description': 'Bâtiment non trouvé'
-            }
-        }
+            ),
+            400: {"description": "Requête invalide"},
+            404: {"description": "Bâtiment non trouvé"},
+        },
     )
     def get(self, request, *args, **kwargs):
         search = BuildingGuess()
@@ -353,12 +350,12 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
         return qs
 
     @extend_schema(
-        tags=['Bâtiment'],
-        operation_id='list_buildings',
-        summary='Listing de bâtiments',
+        tags=["Bâtiment"],
+        operation_id="list_buildings",
+        summary="Listing de bâtiments",
         description=(
-                "Ce endpoint permet de récupérer une liste paginée de bâtiments. "
-                "Des filtres, notamment par code INSEE de la commune, sont disponibles."
+            "Ce endpoint permet de récupérer une liste paginée de bâtiments. "
+            "Des filtres, notamment par code INSEE de la commune, sont disponibles."
         ),
         auth=[],
         parameters=[
@@ -435,81 +432,83 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
             ),
         ],
         responses={
-            200: OpenApiResponse(response=BuildingSerializer(many=True), examples=[
-                OpenApiExample(name='Exemple', value=[
-                    {
-                        "rnb_id": "QBAAG16VCJWA",
-                        "status": "constructed",
-                        "point": {
-                            "type": "Point",
-                            "coordinates": [
-                                3.584410393780201,
-                                49.52799819019749
-                            ]
-                        },
-                        "addresses": [
+            200: OpenApiResponse(
+                response=BuildingSerializer(many=True),
+                examples=[
+                    OpenApiExample(
+                        name="Exemple",
+                        value=[
                             {
-                                "id": "02191_0020_00003",
-                                "source": "bdnb",
-                                "street_number": "3",
-                                "street_rep": "",
-                                "street_name": "de l'eglise",
-                                "street_type": "rue",
-                                "city_name": "Chivy-lès-Étouvelles",
-                                "city_zipcode": "02000",
-                                "city_insee_code": "02191"
-                            }
+                                "rnb_id": "QBAAG16VCJWA",
+                                "status": "constructed",
+                                "point": {
+                                    "type": "Point",
+                                    "coordinates": [
+                                        3.584410393780201,
+                                        49.52799819019749,
+                                    ],
+                                },
+                                "addresses": [
+                                    {
+                                        "id": "02191_0020_00003",
+                                        "source": "bdnb",
+                                        "street_number": "3",
+                                        "street_rep": "",
+                                        "street_name": "de l'eglise",
+                                        "street_type": "rue",
+                                        "city_name": "Chivy-lès-Étouvelles",
+                                        "city_zipcode": "02000",
+                                        "city_insee_code": "02191",
+                                    }
+                                ],
+                                "ext_ids": [
+                                    {
+                                        "id": "bdnb-bc-3B85-TYM9-FDSX",
+                                        "source": "bdnb",
+                                        "created_at": "2023-12-07T13:20:58.310444+00:00",
+                                        "source_version": "2023_01",
+                                    }
+                                ],
+                            },
+                            {
+                                "rnb_id": "FXFJZNZYGTED",
+                                "status": "constructed",
+                                "point": {
+                                    "type": "Point",
+                                    "coordinates": [
+                                        5.775791408470412,
+                                        45.256939624268206,
+                                    ],
+                                },
+                                "addresses": [
+                                    {
+                                        "id": "02191_0020_00005",
+                                        "source": "bdnb",
+                                        "street_number": "5",
+                                        "street_rep": "",
+                                        "street_name": "de l'eglise",
+                                        "street_type": "rue",
+                                        "city_name": "Chivy-lès-Étouvelles",
+                                        "city_zipcode": "02000",
+                                        "city_insee_code": "02191",
+                                    }
+                                ],
+                                "ext_ids": [
+                                    {
+                                        "id": "bdnb-bc-3B86-TYM9-FRTS",
+                                        "source": "bdnb",
+                                        "created_at": "2023-12-07T13:25:58.310444+00:00",
+                                        "source_version": "2023_01",
+                                    }
+                                ],
+                            },
                         ],
-                        "ext_ids": [
-                            {
-                                "id": "bdnb-bc-3B85-TYM9-FDSX",
-                                "source": "bdnb",
-                                "created_at": "2023-12-07T13:20:58.310444+00:00",
-                                "source_version": "2023_01"
-                            }
-                        ]
-                    },
-                    {
-                        "rnb_id": "FXFJZNZYGTED",
-                        "status": "constructed",
-                        "point": {
-                            "type": "Point",
-                            "coordinates": [
-                                5.775791408470412,
-                                45.256939624268206
-                            ]
-                        },
-                        "addresses": [
-                            {
-                                "id": "02191_0020_00005",
-                                "source": "bdnb",
-                                "street_number": "5",
-                                "street_rep": "",
-                                "street_name": "de l'eglise",
-                                "street_type": "rue",
-                                "city_name": "Chivy-lès-Étouvelles",
-                                "city_zipcode": "02000",
-                                "city_insee_code": "02191"
-                            }
-                        ],
-                        "ext_ids": [
-                            {
-                                "id": "bdnb-bc-3B86-TYM9-FRTS",
-                                "source": "bdnb",
-                                "created_at": "2023-12-07T13:25:58.310444+00:00",
-                                "source_version": "2023_01"
-                            }
-                        ]
-                    }
-                ])
-            ]),
-            400: {
-                'description': 'Requête invalide'
-            },
-            404: {
-                'description': 'Bâtiment non trouvé'
-            }
-        }
+                    )
+                ],
+            ),
+            400: {"description": "Requête invalide"},
+            404: {"description": "Bâtiment non trouvé"},
+        },
     )
     def list(self, request, *args, **kwargs):
         """
@@ -518,63 +517,64 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
         return super().list(request, *args, **kwargs)
 
     @extend_schema(
-        tags=['Bâtiment'],
-        operation_id='get_building',
-        summary='Consultation d\'un bâtiment',
+        tags=["Bâtiment"],
+        operation_id="get_building",
+        summary="Consultation d'un bâtiment",
         description=(
-                "Ce endpoint permet de récupérer l'ensemble des attributs d'un bâtiment à partir de son identifiant RNB. "
-                "L'API renvoie les informations détaillées telles que l'ID du bâtiment, le statut, la géolocalisation, "
-                "les adresses associées et les identifiants externes."
+            "Ce endpoint permet de récupérer l'ensemble des attributs d'un bâtiment à partir de son identifiant RNB. "
+            "L'API renvoie les informations détaillées telles que l'ID du bâtiment, le statut, la géolocalisation, "
+            "les adresses associées et les identifiants externes."
         ),
         auth=[],
         parameters=[
             OpenApiParameter(
-                name='rnb_id',
-                description='Identifiant RNB du bâtiment',
+                name="rnb_id",
+                description="Identifiant RNB du bâtiment",
                 required=True,
                 type=str,
-                location=OpenApiParameter.PATH
+                location=OpenApiParameter.PATH,
             )
         ],
         responses={
-            200: OpenApiResponse(response=BuildingSerializer, examples=[
-                OpenApiExample(name='Exemple', value={
-                    "rnb_id": "QBAAG16VCJWA",
-                    "status": "constructed",
-                    "point": {
-                        "type": "Point",
-                        "coordinates": [
-                            3.584410393780201,
-                            49.52799819019749
-                        ]
-                    },
-                    "addresses": [
-                        {
-                            "id": "02191_0020_00003",
-                            "source": "bdnb",
-                            "street_number": "3",
-                            "street_rep": "",
-                            "street_name": "de l'eglise",
-                            "street_type": "rue",
-                            "city_name": "Chivy-lès-Étouvelles",
-                            "city_zipcode": "02000",
-                            "city_insee_code": "02191"
-                        }
-                    ],
-                    "ext_ids": [
-                        {
-                            "id": "bdnb-bc-3B85-TYM9-FDSX",
-                            "source": "bdnb",
-                            "created_at": "2023-12-07T13:20:58.310444+00:00",
-                            "source_version": "2023_01"
-                        }
-                    ]
-                })
-            ]),
-            404: {
-                'description': 'Bâtiment non trouvé'
-            }
-        }
+            200: OpenApiResponse(
+                response=BuildingSerializer,
+                examples=[
+                    OpenApiExample(
+                        name="Exemple",
+                        value={
+                            "rnb_id": "QBAAG16VCJWA",
+                            "status": "constructed",
+                            "point": {
+                                "type": "Point",
+                                "coordinates": [3.584410393780201, 49.52799819019749],
+                            },
+                            "addresses": [
+                                {
+                                    "id": "02191_0020_00003",
+                                    "source": "bdnb",
+                                    "street_number": "3",
+                                    "street_rep": "",
+                                    "street_name": "de l'eglise",
+                                    "street_type": "rue",
+                                    "city_name": "Chivy-lès-Étouvelles",
+                                    "city_zipcode": "02000",
+                                    "city_insee_code": "02191",
+                                }
+                            ],
+                            "ext_ids": [
+                                {
+                                    "id": "bdnb-bc-3B85-TYM9-FDSX",
+                                    "source": "bdnb",
+                                    "created_at": "2023-12-07T13:20:58.310444+00:00",
+                                    "source_version": "2023_01",
+                                }
+                            ],
+                        },
+                    )
+                ],
+            ),
+            404: {"description": "Bâtiment non trouvé"},
+        },
     )
     def retrieve(self, request, *args, **kwargs):
         """
@@ -649,33 +649,141 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
         return search.get_queryset()
 
     @extend_schema(
-        tags=['ADS'],
-        operation_id='list_ads',
-        summary='Liste et recherche d\'ADS',
+        tags=["ADS"],
+        operation_id="list_ads",
+        summary="Liste et recherche d'ADS",
         description=(
-                "Cette API permet de lister et de rechercher des ADS (Autorisation de Droit de Sol). "
-                "Les requêtes doivent être authentifiées en utilisant un token. "
-                "Les filtres de recherche peuvent être passés en tant que paramètres d'URL."
+            "Cette API permet de lister et de rechercher des ADS (Autorisation de Droit de Sol). "
+            "Les requêtes doivent être authentifiées en utilisant un token. "
+            "Les filtres de recherche peuvent être passés en tant que paramètres d'URL."
         ),
         parameters=[
-            OpenApiParameter(name='q', description='Recherche parmi les n° de dossiers (file_number).', required=False, type=str),
-            OpenApiParameter(name='since', description='Récupère tous les dossiers décidés depuis cette date (AAAA-MM-DD).', required=False, type=str),
+            OpenApiParameter(
+                name="q",
+                description="Recherche parmi les n° de dossiers (file_number).",
+                required=False,
+                type=str,
+            ),
+            OpenApiParameter(
+                name="since",
+                description="Récupère tous les dossiers décidés depuis cette date (AAAA-MM-DD).",
+                required=False,
+                type=str,
+            ),
         ],
         responses={
-            200: OpenApiResponse(response=ADSSerializer, examples=[
-                OpenApiExample(name='Exemple', value={
-                    "count": 3,
-                    "next": None,
-                    "previous": None,
-                    "results": [
-                        {
+            200: OpenApiResponse(
+                response=ADSSerializer,
+                examples=[
+                    OpenApiExample(
+                        name="Exemple",
+                        value={
+                            "count": 3,
+                            "next": None,
+                            "previous": None,
+                            "results": [
+                                {
+                                    "file_number": "TEST03818519U9999",
+                                    "decided_at": "2023-06-01",
+                                    "buildings_operations": [
+                                        {
+                                            "rnb_id": "A1B2C3A1B2C3",
+                                            "shape": None,
+                                            "operation": "build",
+                                        },
+                                        {
+                                            "rnb_id": None,
+                                            "shape": {
+                                                "type": "Point",
+                                                "coordinates": [
+                                                    5.722961565015281,
+                                                    45.1851103238598,
+                                                ],
+                                            },
+                                            "operation": "demolish",
+                                        },
+                                        {
+                                            "rnb_id": "1M2N3O1M2N3O",
+                                            "shape": {
+                                                "type": "Point",
+                                                "coordinates": [
+                                                    5.723006573148693,
+                                                    45.1851402293713,
+                                                ],
+                                            },
+                                            "operation": "demolish",
+                                        },
+                                    ],
+                                },
+                                {
+                                    "file_number": "PC3807123200WW",
+                                    "decided_at": "2023-05-01",
+                                    "buildings_operations": [
+                                        {
+                                            "rnb_id": "FXFJZNZYGTED",
+                                            "shape": None,
+                                            "operation": "build",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "file_number": "PC384712301337",
+                                    "decided_at": "2023-02-22",
+                                    "buildings_operations": [
+                                        {
+                                            "rnb_id": "RXNOSN2DUCLG",
+                                            "geometry": {
+                                                "type": "Point",
+                                                "coordinates": [
+                                                    5.775791408470412,
+                                                    45.256939624268206,
+                                                ],
+                                            },
+                                            "operation": "modify",
+                                        }
+                                    ],
+                                },
+                            ],
+                        },
+                    )
+                ],
+            )
+        },
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
+
+    @extend_schema(
+        tags=["ADS"],
+        operation_id="get_ads",
+        summary="Obtenir une ADS",
+        description=(
+            "Cette API permet de récupérer une ADS (Autorisation de Droit de Sol). "
+            "Les requêtes doivent être authentifiées en utilisant un token. "
+        ),
+        parameters=[
+            OpenApiParameter(
+                name="file_number",
+                description="Récupération par n° de dossier (file_number).",
+                required=True,
+                type=str,
+                location=OpenApiParameter.PATH,
+            ),
+        ],
+        responses={
+            200: OpenApiResponse(
+                response=ADSSerializer,
+                examples=[
+                    OpenApiExample(
+                        name="Exemple",
+                        value={
                             "file_number": "TEST03818519U9999",
                             "decided_at": "2023-06-01",
                             "buildings_operations": [
                                 {
                                     "rnb_id": "A1B2C3A1B2C3",
                                     "shape": None,
-                                    "operation": "build"
+                                    "operation": "build",
                                 },
                                 {
                                     "rnb_id": None,
@@ -683,10 +791,10 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                                         "type": "Point",
                                         "coordinates": [
                                             5.722961565015281,
-                                            45.1851103238598
-                                        ]
+                                            45.1851103238598,
+                                        ],
                                     },
-                                    "operation": "demolish"
+                                    "operation": "demolish",
                                 },
                                 {
                                     "rnb_id": "1M2N3O1M2N3O",
@@ -694,202 +802,123 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                                         "type": "Point",
                                         "coordinates": [
                                             5.723006573148693,
-                                            45.1851402293713
-                                        ]
+                                            45.1851402293713,
+                                        ],
                                     },
-                                    "operation": "demolish"
-                                }
-                            ]
+                                    "operation": "demolish",
+                                },
+                            ],
                         },
-                        {
-                            "file_number": "PC3807123200WW",
-                            "decided_at": "2023-05-01",
-                            "buildings_operations": [
-                                {
-                                    "rnb_id": "FXFJZNZYGTED",
-                                    "shape": None,
-                                    "operation": "build"
-                                }
-                            ]
-                        },
-                        {
-                            "file_number": "PC384712301337",
-                            "decided_at": "2023-02-22",
-                            "buildings_operations": [
-                                {
-                                    "rnb_id": "RXNOSN2DUCLG",
-                                    "geometry": {
-                                        "type": "Point",
-                                        "coordinates": [
-                                            5.775791408470412,
-                                            45.256939624268206
-                                        ]
-                                    },
-                                    "operation": "modify"
-                                }
-                            ]
-                        },
-                    ]
-                })
-            ])
-        }
-    )
-    def list(self, request, *args, **kwargs):
-        return super().list(request, *args, **kwargs)
-
-    @extend_schema(
-        tags=['ADS'],
-        operation_id='get_ads',
-        summary='Obtenir une ADS',
-        description=(
-                "Cette API permet de récupérer une ADS (Autorisation de Droit de Sol). "
-                "Les requêtes doivent être authentifiées en utilisant un token. "
-        ),
-        parameters=[
-            OpenApiParameter(
-                name='file_number',
-                 description='Récupération par n° de dossier (file_number).',
-                 required=True,
-                 type=str,
-                 location=OpenApiParameter.PATH
-            ),
-        ],
-        responses={
-            200: OpenApiResponse(response=ADSSerializer, examples=[
-                OpenApiExample(name='Exemple', value={
-                    "file_number": "TEST03818519U9999",
-                    "decided_at": "2023-06-01",
-                    "buildings_operations": [
-                        {
-                            "rnb_id": "A1B2C3A1B2C3",
-                            "shape": None,
-                            "operation": "build"
-                        },
-                        {
-                            "rnb_id": None,
-                            "shape": {
-                                "type": "Point",
-                                "coordinates": [
-                                    5.722961565015281,
-                                    45.1851103238598
-                                ]
-                            },
-                            "operation": "demolish"
-                        },
-                        {
-                            "rnb_id": "1M2N3O1M2N3O",
-                            "shape": {
-                                "type": "Point",
-                                "coordinates": [
-                                    5.723006573148693,
-                                    45.1851402293713
-                                ]
-                            },
-                            "operation": "demolish"
-                        }
-                    ]
-                })
-            ])
-        }
+                    )
+                ],
+            )
+        },
     )
     def retrieve(self, request, *args, **kwargs):
         return super().retrieve(request, *args, **kwargs)
 
     @extend_schema(
-        tags=['ADS'],
-        operation_id='create_ads',
-        summary='Création d\'une ADS',
+        tags=["ADS"],
+        operation_id="create_ads",
+        summary="Création d'une ADS",
         description=(
-                "Ce endpoint permet de créer une Autorisation du Droit des Sols (ADS) dans le RNB. "
-                "L'API ADS est réservée aux communes et requiert une authentification par token."
+            "Ce endpoint permet de créer une Autorisation du Droit des Sols (ADS) dans le RNB. "
+            "L'API ADS est réservée aux communes et requiert une authentification par token."
         ),
         request=ADSSerializer,
         responses={
-            201: OpenApiResponse(response=ADSSerializer, examples=[
-                OpenApiExample(name='Exemple', value={
-                    "file_number": "PCXXXXXXXXXX",
-                    "decided_at": "2019-03-18",
-                    "buildings_operations": [
-                        {
-                            "operation": "demolish",
-                            "rnb_id": "ABCD1234WXYZ",
-                            "shape": None
+            201: OpenApiResponse(
+                response=ADSSerializer,
+                examples=[
+                    OpenApiExample(
+                        name="Exemple",
+                        value={
+                            "file_number": "PCXXXXXXXXXX",
+                            "decided_at": "2019-03-18",
+                            "buildings_operations": [
+                                {
+                                    "operation": "demolish",
+                                    "rnb_id": "ABCD1234WXYZ",
+                                    "shape": None,
+                                },
+                                {
+                                    "operation": "build",
+                                    "rnb_id": None,
+                                    "shape": {
+                                        "type": "Point",
+                                        "coordinates": [
+                                            2.3552747458487002,
+                                            48.86958288638419,
+                                        ],
+                                    },
+                                },
+                            ],
                         },
-                        {
-                            "operation": "build",
-                            "rnb_id": None,
-                            "shape": {
-                                "type": "Point",
-                                "coordinates": [2.3552747458487002, 48.86958288638419]
-                            }
-                        }
-                    ]
-                })
-            ]),
-            400: {
-                'description': 'Requête invalide'
-            }
-        }
+                    )
+                ],
+            ),
+            400: {"description": "Requête invalide"},
+        },
     )
     def create(self, request, *args, **kwargs):
         return super().create(request, *args, **kwargs)
 
-
     @extend_schema(
-        tags=['ADS'],
-        operation_id='update_ads',
-        summary='Modification d\'une ADS',
+        tags=["ADS"],
+        operation_id="update_ads",
+        summary="Modification d'une ADS",
         description=(
-                "Ce endpoint permet de modifier une Autorisation du Droit des Sols (ADS) existante dans le RNB. "
-                "L'API ADS est réservée aux communes et requiert une authentification par token."
+            "Ce endpoint permet de modifier une Autorisation du Droit des Sols (ADS) existante dans le RNB. "
+            "L'API ADS est réservée aux communes et requiert une authentification par token."
         ),
         request=ADSSerializer,
         responses={
-            200: OpenApiResponse(response=ADSSerializer, examples=[
-                OpenApiExample(name='Exemple', value={
-                    "file_number": "PCXXXXXXXXXX",
-                    "decided_at": "2019-03-10",
-                    "buildings_operations": [
-                        {
-                            "operation": "demolish",
-                            "rnb_id": "7865HG43PLS9",
-                            "shape": None
+            200: OpenApiResponse(
+                response=ADSSerializer,
+                examples=[
+                    OpenApiExample(
+                        name="Exemple",
+                        value={
+                            "file_number": "PCXXXXXXXXXX",
+                            "decided_at": "2019-03-10",
+                            "buildings_operations": [
+                                {
+                                    "operation": "demolish",
+                                    "rnb_id": "7865HG43PLS9",
+                                    "shape": None,
+                                },
+                                {
+                                    "operation": "build",
+                                    "rnb_id": None,
+                                    "shape": {
+                                        "type": "Point",
+                                        "coordinates": [
+                                            2.3552747458487002,
+                                            48.86958288638419,
+                                        ],
+                                    },
+                                },
+                            ],
                         },
-                        {
-                            "operation": "build",
-                            "rnb_id": None,
-                            "shape": {
-                                "type": "Point",
-                                "coordinates": [2.3552747458487002, 48.86958288638419]
-                            }
-                        }
-                    ]
-                })
-            ]),
-            400: {
-                'description': 'Requête invalide'
-            },
-            404: {
-                'description': 'ADS non trouvée'
-            }
-        }
+                    )
+                ],
+            ),
+            400: {"description": "Requête invalide"},
+            404: {"description": "ADS non trouvée"},
+        },
     )
     def update(self, request, *args, **kwargs):
         return super().update(request, *args, **kwargs)
 
     @extend_schema(
-        tags=['ADS'],
-        operation_id='delete_ads',
-        summary='Suppression d\'une ADS',
-        description='Ce endpoint permet de supprimer une Autorisation du Droit des Sols (ADS) existante dans le RNB.',
+        tags=["ADS"],
+        operation_id="delete_ads",
+        summary="Suppression d'une ADS",
+        description="Ce endpoint permet de supprimer une Autorisation du Droit des Sols (ADS) existante dans le RNB.",
         responses={
-            204: {
-                'description': 'ADS supprimée avec succès'
-            },
-            404: {
-                'description': 'ADS non trouvée'
-            }
-        }
+            204: {"description": "ADS supprimée avec succès"},
+            404: {"description": "ADS non trouvée"},
+        },
     )
     def destroy(self, request, *args, **kwargs):
         return super().destroy(request, *args, **kwargs)
@@ -897,48 +926,46 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
 
 class GetVectorTileView(APIView):
     @extend_schema(
-        tags=['Tile'],
-        operation_id='get_vector_tile',
-        summary='Obtenir une tuile vectorielle',
+        tags=["Tile"],
+        operation_id="get_vector_tile",
+        summary="Obtenir une tuile vectorielle",
         description=(
-                "Cette API fournit des tuiles vectorielles au format PBF permettant d'intégrer les bâtiments "
-                "du Référentiel National des Bâtiments (RNB) dans une cartographie. Chaque tuile contient des points "
-                "représentant des bâtiments avec un attribut 'rnb_id'. Les tuiles sont utilisables avec un niveau de zoom "
-                "minimal de 16 et peuvent être intégrées dans des outils comme QGIS ou des sites web."
+            "Cette API fournit des tuiles vectorielles au format PBF permettant d'intégrer les bâtiments "
+            "du Référentiel National des Bâtiments (RNB) dans une cartographie. Chaque tuile contient des points "
+            "représentant des bâtiments avec un attribut 'rnb_id'. Les tuiles sont utilisables avec un niveau de zoom "
+            "minimal de 16 et peuvent être intégrées dans des outils comme QGIS ou des sites web."
         ),
         auth=[],
         parameters=[
             OpenApiParameter(
-                name='x',
-                description='Coordonnée X de la tuile',
+                name="x",
+                description="Coordonnée X de la tuile",
                 required=True,
                 type=int,
-                location=OpenApiParameter.PATH
+                location=OpenApiParameter.PATH,
             ),
             OpenApiParameter(
-                name='y',
-                description='Coordonnée Y de la tuile',
+                name="y",
+                description="Coordonnée Y de la tuile",
                 required=True,
                 type=int,
-                location=OpenApiParameter.PATH
+                location=OpenApiParameter.PATH,
             ),
             OpenApiParameter(
-                name='z',
-                description='Niveau de zoom de la tuile',
+                name="z",
+                description="Niveau de zoom de la tuile",
                 required=True,
                 type=int,
-                location=OpenApiParameter.PATH
+                location=OpenApiParameter.PATH,
             ),
         ],
         responses={
             200: OpenApiResponse(
                 response=OpenApiTypes.BINARY,
-                description='Fichier PBF contenant les tuiles vectorielles'
+                description="Fichier PBF contenant les tuiles vectorielles",
             ),
-            400: {
-                'description': 'Requête invalide'
-            }
-        }
+            400: {"description": "Requête invalide"},
+        },
     )
     def get(self, request, x, y, z):
         # Check the request zoom level
@@ -1014,9 +1041,9 @@ def get_stats(request):
 
 
 @extend_schema(
-    tags=['Bâtiment'],
-    operation_id='get_building_diff',
-    summary='Obtenir les dernières modifications',
+    tags=["Bâtiment"],
+    operation_id="get_building_diff",
+    summary="Obtenir les dernières modifications",
     description="""
         Filtre les modifications apportées au RNB ayant eu lieu strictement après un datetime.
         Les données sont retournées au format CSV.
@@ -1051,20 +1078,26 @@ def get_stats(request):
         ),
     ],
     responses={
-        200: OpenApiResponse(response=OpenApiTypes.STR, examples=[
-            OpenApiExample(name='Exemple', value=(
-                    "action,rnb_id,status,sys_period,point,shape,addresses_id,ext_ids\n"
-                    "create,QBAAG16VCJWA,constructed,\"[2024-04-02,)\",POINT(3.584410393780201 49.52799819019749),,02191_0020_00003,\n"
-                    "update,QBAAG16VCJWA,constructed,\"[2024-04-03,)\",POINT(3.584410393780201 49.52799819019749),,02191_0020_00003,\n"
-            ))
-        ]),
+        200: OpenApiResponse(
+            response=OpenApiTypes.STR,
+            examples=[
+                OpenApiExample(
+                    name="Exemple",
+                    value=(
+                        "action,rnb_id,status,sys_period,point,shape,addresses_id,ext_ids\n"
+                        'create,QBAAG16VCJWA,constructed,"[2024-04-02,)",POINT(3.584410393780201 49.52799819019749),,02191_0020_00003,\n'
+                        'update,QBAAG16VCJWA,constructed,"[2024-04-03,)",POINT(3.584410393780201 49.52799819019749),,02191_0020_00003,\n'
+                    ),
+                )
+            ],
+        ),
         400: {
-            'description': "Le paramètre 'since' est manquant ou incorrect",
+            "description": "Le paramètre 'since' est manquant ou incorrect",
         },
         404: {
-            'description': "Aucune modification trouvée pour les critères donnés",
-        }
-    }
+            "description": "Aucune modification trouvée pour les critères donnés",
+        },
+    },
 )
 @api_view(["GET"])
 def get_diff(request):
@@ -1280,21 +1313,21 @@ class AdsTokenView(APIView):
 
 
 class TokenScheme(OpenApiAuthenticationExtension):
-    target_class = 'rest_framework.authentication.TokenAuthentication'
-    name = 'RNBTokenAuth'
+    target_class = "rest_framework.authentication.TokenAuthentication"
+    name = "RNBTokenAuth"
     priority = 1
 
     def get_security_definition(self, auto_schema):
         return {
-            'type': 'apiKey',
-            'in': 'header',
-            'name': 'Authorization',
-            'description': 'Toutes les requêtes liées aux ADS doivent faire l’objet d’une authentification. '
-                           'Pour vous identifier, utilisez le token fourni par l’équipe du RNB. '
-                           'Pour faire une demande de token, renseignez ce formulaire.\n\n'
-                           'Ajoutez une clé `Authorization` aux headers HTTP de chacune de vos requêtes. '
-                           'La valeur doit être votre token préfixé de la chaîne “Token”. '
-                           'Un espace sépare “Token” et votre token.\n\n'
-                           'Exemple:\n\n'
-                           '`Authorization: Token 9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b`'
+            "type": "apiKey",
+            "in": "header",
+            "name": "Authorization",
+            "description": "Toutes les requêtes liées aux ADS doivent faire l’objet d’une authentification. "
+            "Pour vous identifier, utilisez le token fourni par l’équipe du RNB. "
+            "Pour faire une demande de token, renseignez ce formulaire.\n\n"
+            "Ajoutez une clé `Authorization` aux headers HTTP de chacune de vos requêtes. "
+            "La valeur doit être votre token préfixé de la chaîne “Token”. "
+            "Un espace sépare “Token” et votre token.\n\n"
+            "Exemple:\n\n"
+            "`Authorization: Token 9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b`",
         }

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -65,77 +65,68 @@ class RNBLoggingMixin(LoggingMixin):
 
 class BuildingGuessView(RNBLoggingMixin, APIView):
     @extend_schema(
-        operation_id='guess_building',
-        summary='Identification de bâtiment',
+        operation_id="guess_building",
+        summary="Identification de bâtiment",
         description=(
-                "Ce endpoint permet de trouver un ou plusieurs bâtiments correspondant à une série de critères. "
-                "Il permet d'accueillir des données imprécises et tente de les combiner pour fournir le meilleur résultat."
+            "Ce endpoint permet de trouver un ou plusieurs bâtiments correspondant à une série de critères. "
+            "Il permet d'accueillir des données imprécises et tente de les combiner pour fournir le meilleur résultat."
         ),
         parameters=[
             OpenApiParameter(
-                name='address',
+                name="address",
                 description=(
-                        "Utilise les geocoders de la Base Adresse Nationale et d'Open Street Map pour tenter "
-                        "de géolocaliser l'adresse indiquée."
+                    "Utilise les geocoders de la Base Adresse Nationale et d'Open Street Map pour tenter "
+                    "de géolocaliser l'adresse indiquée."
                 ),
                 required=False,
                 type=str,
                 examples=[
                     OpenApiExample(
-                        "Exemple d'adresse",
-                        value="10 rue de la paix, Mérignac"
+                        "Exemple d'adresse", value="10 rue de la paix, Mérignac"
                     )
-                ]
+                ],
             ),
             OpenApiParameter(
-                name='name',
+                name="name",
                 description=(
-                        "Utilise un geocoder Open Street Map pour tenter de géolocaliser le lieu donné."
+                    "Utilise un geocoder Open Street Map pour tenter de géolocaliser le lieu donné."
                 ),
                 required=False,
                 type=str,
                 examples=[
-                    OpenApiExample(
-                        "Exemple de lieu",
-                        value="Notre Dame de Paris"
-                    )
-                ]
+                    OpenApiExample("Exemple de lieu", value="Notre Dame de Paris")
+                ],
             ),
             OpenApiParameter(
-                name='point',
+                name="point",
                 description=(
-                        "Favorise les bâtiments en fonction de leur position par rapport au point indiqué "
-                        "(latitude et longitude séparées par une virgule)."
+                    "Favorise les bâtiments en fonction de leur position par rapport au point indiqué "
+                    "(latitude et longitude séparées par une virgule)."
                 ),
                 required=False,
                 type=str,
                 examples=[
                     OpenApiExample(
                         "Exemple de point",
-                        value="44.84114313595151,-0.5705289444867035"
+                        value="44.84114313595151,-0.5705289444867035",
                     )
-                ]
+                ],
             ),
             OpenApiParameter(
-                name='page',
+                name="page",
                 description="Pagination des résultats de recherche.",
                 required=False,
                 type=int,
                 default=1,
-                examples=[
-                    OpenApiExample(
-                        "Page par défaut",
-                        value=1
-                    )
-                ]
-            )
+                examples=[OpenApiExample("Page par défaut", value=1)],
+            ),
         ],
         responses={
             200: {
-                'description': 'Liste des bâtiments identifiés',
-                'content': {
-                    'application/json': {
-                        'example': [
+                "description": "Liste des bâtiments identifiés",
+                "content": {
+                    "application/json": {
+                        "example": [
                             {
                                 "rnb_id": "QBAAG16VCJWA",
                                 "score": 0.753986390,
@@ -144,8 +135,8 @@ class BuildingGuessView(RNBLoggingMixin, APIView):
                                     "type": "Point",
                                     "coordinates": [
                                         3.584410393780201,
-                                        49.52799819019749
-                                    ]
+                                        49.52799819019749,
+                                    ],
                                 },
                                 "addresses": [
                                     {
@@ -157,7 +148,7 @@ class BuildingGuessView(RNBLoggingMixin, APIView):
                                         "street_type": "rue",
                                         "city_name": "Chivy-lès-Étouvelles",
                                         "city_zipcode": "02000",
-                                        "city_insee_code": "02191"
+                                        "city_insee_code": "02191",
                                     }
                                 ],
                                 "ext_ids": [
@@ -165,9 +156,9 @@ class BuildingGuessView(RNBLoggingMixin, APIView):
                                         "id": "bdnb-bc-3B85-TYM9-FDSX",
                                         "source": "bdnb",
                                         "created_at": "2023-12-07T13:20:58.310444+00:00",
-                                        "source_version": "2023_01"
+                                        "source_version": "2023_01",
                                     }
-                                ]
+                                ],
                             },
                             {
                                 "rnb_id": "GT5Y98K4BV51",
@@ -175,10 +166,7 @@ class BuildingGuessView(RNBLoggingMixin, APIView):
                                 "status": "constructed",
                                 "point": {
                                     "type": "Point",
-                                    "coordinates": [
-                                        6.269684,
-                                        43.89756654
-                                    ]
+                                    "coordinates": [6.269684, 43.89756654],
                                 },
                                 "addresses": [
                                     {
@@ -190,7 +178,7 @@ class BuildingGuessView(RNBLoggingMixin, APIView):
                                         "street_type": "rue",
                                         "city_name": "Chivy-lès-Étouvelles",
                                         "city_zipcode": "02000",
-                                        "city_insee_code": "02191"
+                                        "city_insee_code": "02191",
                                     }
                                 ],
                                 "ext_ids": [
@@ -198,21 +186,17 @@ class BuildingGuessView(RNBLoggingMixin, APIView):
                                         "id": "bdnb-bc-3B86-TYM9-FRTS",
                                         "source": "bdnb",
                                         "created_at": "2023-12-07T13:25:58.310444+00:00",
-                                        "source_version": "2023_01"
+                                        "source_version": "2023_01",
                                     }
-                                ]
-                            }
+                                ],
+                            },
                         ]
                     }
-                }
+                },
             },
-            400: {
-                'description': 'Requête invalide'
-            },
-            404: {
-                'description': 'Bâtiment non trouvé'
-            }
-        }
+            400: {"description": "Requête invalide"},
+            404: {"description": "Bâtiment non trouvé"},
+        },
     )
     def get(self, request, *args, **kwargs):
         search = BuildingGuess()
@@ -484,35 +468,32 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
         return super().list(request, *args, **kwargs)
 
     @extend_schema(
-        operation_id='get_building',
-        summary='Consultation d\'un bâtiment',
+        operation_id="get_building",
+        summary="Consultation d'un bâtiment",
         description=(
-                "Ce endpoint permet de récupérer l'ensemble des attributs d'un bâtiment à partir de son identifiant RNB. "
-                "L'API renvoie les informations détaillées telles que l'ID du bâtiment, le statut, la géolocalisation, "
-                "les adresses associées et les identifiants externes."
+            "Ce endpoint permet de récupérer l'ensemble des attributs d'un bâtiment à partir de son identifiant RNB. "
+            "L'API renvoie les informations détaillées telles que l'ID du bâtiment, le statut, la géolocalisation, "
+            "les adresses associées et les identifiants externes."
         ),
         parameters=[
             OpenApiParameter(
-                name='rnb_id',
-                description='Identifiant RNB du bâtiment',
+                name="rnb_id",
+                description="Identifiant RNB du bâtiment",
                 required=True,
-                type=str
+                type=str,
             )
         ],
         responses={
             200: {
-                'description': 'Détails du bâtiment',
-                'content': {
-                    'application/json': {
-                        'example': {
+                "description": "Détails du bâtiment",
+                "content": {
+                    "application/json": {
+                        "example": {
                             "rnb_id": "QBAAG16VCJWA",
                             "status": "constructed",
                             "point": {
                                 "type": "Point",
-                                "coordinates": [
-                                    3.584410393780201,
-                                    49.52799819019749
-                                ]
+                                "coordinates": [3.584410393780201, 49.52799819019749],
                             },
                             "addresses": [
                                 {
@@ -524,7 +505,7 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                                     "street_type": "rue",
                                     "city_name": "Chivy-lès-Étouvelles",
                                     "city_zipcode": "02000",
-                                    "city_insee_code": "02191"
+                                    "city_insee_code": "02191",
                                 }
                             ],
                             "ext_ids": [
@@ -532,17 +513,15 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                                     "id": "bdnb-bc-3B85-TYM9-FDSX",
                                     "source": "bdnb",
                                     "created_at": "2023-12-07T13:20:58.310444+00:00",
-                                    "source_version": "2023_01"
+                                    "source_version": "2023_01",
                                 }
-                            ]
+                            ],
                         }
                     }
-                }
+                },
             },
-            404: {
-                'description': 'Bâtiment non trouvé'
-            }
-        }
+            404: {"description": "Bâtiment non trouvé"},
+        },
     )
     def retrieve(self, request, *args, **kwargs):
         """
@@ -609,20 +588,30 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
     http_method_names = ["get", "post", "put", "delete"]
 
     @extend_schema(
-        operation_id='list_ads',
-        summary='Liste et recherche d\'ADS',
+        operation_id="list_ads",
+        summary="Liste et recherche d'ADS",
         description=(
-                "Cette API permet de lister et de rechercher des ADS (Autorisation de Droit de Sol). "
-                "Les requêtes doivent être authentifiées en utilisant un token. "
-                "Les filtres de recherche peuvent être passés en tant que paramètres d'URL."
+            "Cette API permet de lister et de rechercher des ADS (Autorisation de Droit de Sol). "
+            "Les requêtes doivent être authentifiées en utilisant un token. "
+            "Les filtres de recherche peuvent être passés en tant que paramètres d'URL."
         ),
         parameters=[
-            OpenApiParameter(name='q', description='Recherche parmi les n° de dossiers (file_number).', required=False, type=str),
-            OpenApiParameter(name='since', description='Récupère tous les dossiers décidés depuis cette date (AAAA-MM-DD).', required=False, type=str),
+            OpenApiParameter(
+                name="q",
+                description="Recherche parmi les n° de dossiers (file_number).",
+                required=False,
+                type=str,
+            ),
+            OpenApiParameter(
+                name="since",
+                description="Récupère tous les dossiers décidés depuis cette date (AAAA-MM-DD).",
+                required=False,
+                type=str,
+            ),
         ],
         responses={
             200: OpenApiExample(
-                'Exemple de réponse',
+                "Exemple de réponse",
                 value={
                     "count": 3,
                     "next": None,
@@ -635,7 +624,7 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                                 {
                                     "rnb_id": "A1B2C3A1B2C3",
                                     "shape": None,
-                                    "operation": "build"
+                                    "operation": "build",
                                 },
                                 {
                                     "rnb_id": None,
@@ -643,10 +632,10 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                                         "type": "Point",
                                         "coordinates": [
                                             5.722961565015281,
-                                            45.1851103238598
-                                        ]
+                                            45.1851103238598,
+                                        ],
                                     },
-                                    "operation": "demolish"
+                                    "operation": "demolish",
                                 },
                                 {
                                     "rnb_id": "1M2N3O1M2N3O",
@@ -654,12 +643,12 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                                         "type": "Point",
                                         "coordinates": [
                                             5.723006573148693,
-                                            45.1851402293713
-                                        ]
+                                            45.1851402293713,
+                                        ],
                                     },
-                                    "operation": "demolish"
-                                }
-                            ]
+                                    "operation": "demolish",
+                                },
+                            ],
                         },
                         {
                             "file_number": "PC3807123200WW",
@@ -668,9 +657,9 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                                 {
                                     "rnb_id": "FXFJZNZYGTED",
                                     "shape": None,
-                                    "operation": "build"
+                                    "operation": "build",
                                 }
-                            ]
+                            ],
                         },
                         {
                             "file_number": "PC384712301337",
@@ -682,19 +671,19 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                                         "type": "Point",
                                         "coordinates": [
                                             5.775791408470412,
-                                            45.256939624268206
-                                        ]
+                                            45.256939624268206,
+                                        ],
                                     },
-                                    "operation": "modify"
+                                    "operation": "modify",
                                 }
-                            ]
+                            ],
                         },
-                    ]
+                    ],
                 },
                 response_only=True,
-                status_codes=['200']
+                status_codes=["200"],
             )
-        }
+        },
     )
     def get_queryset(self):
         search = ADSSearch(**self.request.query_params.dict())
@@ -705,162 +694,147 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
         return search.get_queryset()
 
     @extend_schema(
-        operation_id='create_ads',
-        summary='Création d\'une ADS',
+        operation_id="create_ads",
+        summary="Création d'une ADS",
         description=(
-                "Ce endpoint permet de créer une Autorisation du Droit des Sols (ADS) dans le RNB. "
-                "L'API ADS est réservée aux communes et requiert une authentification par token."
+            "Ce endpoint permet de créer une Autorisation du Droit des Sols (ADS) dans le RNB. "
+            "L'API ADS est réservée aux communes et requiert une authentification par token."
         ),
         request=ADSSerializer,
         responses={
             201: {
-                'description': 'ADS créée avec succès',
-                'content': {
-                    'application/json': {
-                        'example': {
+                "description": "ADS créée avec succès",
+                "content": {
+                    "application/json": {
+                        "example": {
                             "file_number": "PCXXXXXXXXXX",
                             "decided_at": "2019-03-18",
                             "buildings_operations": [
                                 {
                                     "operation": "demolish",
                                     "rnb_id": "ABCD1234WXYZ",
-                                    "shape": None
+                                    "shape": None,
                                 },
                                 {
                                     "operation": "build",
                                     "rnb_id": None,
                                     "shape": {
                                         "type": "Point",
-                                        "coordinates": [2.3552747458487002, 48.86958288638419]
-                                    }
-                                }
-                            ]
+                                        "coordinates": [
+                                            2.3552747458487002,
+                                            48.86958288638419,
+                                        ],
+                                    },
+                                },
+                            ],
                         }
                     }
-                }
+                },
             },
-            400: {
-                'description': 'Requête invalide'
-            }
-        }
+            400: {"description": "Requête invalide"},
+        },
     )
     def create(self, request, *args, **kwargs):
         return super().create(request, *args, **kwargs)
 
-
     @extend_schema(
-        operation_id='update_ads',
-        summary='Modification d\'une ADS',
+        operation_id="update_ads",
+        summary="Modification d'une ADS",
         description=(
-                "Ce endpoint permet de modifier une Autorisation du Droit des Sols (ADS) existante dans le RNB. "
-                "L'API ADS est réservée aux communes et requiert une authentification par token."
+            "Ce endpoint permet de modifier une Autorisation du Droit des Sols (ADS) existante dans le RNB. "
+            "L'API ADS est réservée aux communes et requiert une authentification par token."
         ),
         request=ADSSerializer,
         responses={
             200: {
-                'description': 'ADS modifiée avec succès',
-                'content': {
-                    'application/json': {
-                        'example': {
+                "description": "ADS modifiée avec succès",
+                "content": {
+                    "application/json": {
+                        "example": {
                             "file_number": "PCXXXXXXXXXX",
                             "decided_at": "2019-03-10",
                             "buildings_operations": [
                                 {
                                     "operation": "demolish",
                                     "rnb_id": "7865HG43PLS9",
-                                    "shape": None
+                                    "shape": None,
                                 },
                                 {
                                     "operation": "build",
                                     "rnb_id": None,
                                     "shape": {
                                         "type": "Point",
-                                        "coordinates": [2.3552747458487002, 48.86958288638419]
-                                    }
-                                }
-                            ]
+                                        "coordinates": [
+                                            2.3552747458487002,
+                                            48.86958288638419,
+                                        ],
+                                    },
+                                },
+                            ],
                         }
                     }
-                }
+                },
             },
-            400: {
-                'description': 'Requête invalide'
-            },
-            404: {
-                'description': 'ADS non trouvée'
-            }
-        }
+            400: {"description": "Requête invalide"},
+            404: {"description": "ADS non trouvée"},
+        },
     )
     def update(self, request, *args, **kwargs):
         return super().update(request, *args, **kwargs)
 
     @extend_schema(
-        operation_id='delete_ads',
-        summary='Suppression d\'une ADS',
-        description='Ce endpoint permet de supprimer une Autorisation du Droit des Sols (ADS) existante dans le RNB.',
+        operation_id="delete_ads",
+        summary="Suppression d'une ADS",
+        description="Ce endpoint permet de supprimer une Autorisation du Droit des Sols (ADS) existante dans le RNB.",
         responses={
-            204: {
-                'description': 'ADS supprimée avec succès'
-            },
-            404: {
-                'description': 'ADS non trouvée'
-            }
-        }
+            204: {"description": "ADS supprimée avec succès"},
+            404: {"description": "ADS non trouvée"},
+        },
     )
     def destroy(self, request, *args, **kwargs):
         return super().destroy(request, *args, **kwargs)
 
+
 @extend_schema(
-    operation_id='get_vector_tiles',
-    summary='Obtenir des tuiles vectorielles',
+    operation_id="get_vector_tiles",
+    summary="Obtenir des tuiles vectorielles",
     description=(
-            "Cette API fournit des tuiles vectorielles au format PBF permettant d'intégrer les bâtiments "
-            "du Référentiel National des Bâtiments (RNB) dans une cartographie. Chaque tuile contient des points "
-            "représentant des bâtiments avec un attribut 'rnb_id'. Les tuiles sont utilisables avec un niveau de zoom "
-            "minimal de 16 et peuvent être intégrées dans des outils comme QGIS ou des sites web."
+        "Cette API fournit des tuiles vectorielles au format PBF permettant d'intégrer les bâtiments "
+        "du Référentiel National des Bâtiments (RNB) dans une cartographie. Chaque tuile contient des points "
+        "représentant des bâtiments avec un attribut 'rnb_id'. Les tuiles sont utilisables avec un niveau de zoom "
+        "minimal de 16 et peuvent être intégrées dans des outils comme QGIS ou des sites web."
     ),
     parameters=[
         {
-            'name': 'x',
-            'required': True,
-            'description': 'Coordonnée X de la tuile',
-            'schema': {
-                'type': 'integer'
-            }
+            "name": "x",
+            "required": True,
+            "description": "Coordonnée X de la tuile",
+            "schema": {"type": "integer"},
         },
         {
-            'name': 'y',
-            'required': True,
-            'description': 'Coordonnée Y de la tuile',
-            'schema': {
-                'type': 'integer'
-            }
+            "name": "y",
+            "required": True,
+            "description": "Coordonnée Y de la tuile",
+            "schema": {"type": "integer"},
         },
         {
-            'name': 'z',
-            'required': True,
-            'description': 'Niveau de zoom de la tuile',
-            'schema': {
-                'type': 'integer'
-            }
-        }
+            "name": "z",
+            "required": True,
+            "description": "Niveau de zoom de la tuile",
+            "schema": {"type": "integer"},
+        },
     ],
     responses={
         200: {
-            'content': {
-                'application/x-protobuf': {
-                    'schema': {
-                        'type': 'string',
-                        'format': 'binary'
-                    }
+            "content": {
+                "application/x-protobuf": {
+                    "schema": {"type": "string", "format": "binary"}
                 }
             },
-            'description': 'Fichier PBF contenant les tuiles vectorielles'
+            "description": "Fichier PBF contenant les tuiles vectorielles",
         },
-        400: {
-            'description': 'Requête invalide'
-        }
-    }
+        400: {"description": "Requête invalide"},
+    },
 )
 def get_tile_point(request, x, y, z):
     # Check the request zoom level

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -64,6 +64,156 @@ class RNBLoggingMixin(LoggingMixin):
 
 
 class BuildingGuessView(RNBLoggingMixin, APIView):
+    @extend_schema(
+        operation_id='guess_building',
+        summary='Identification de bâtiment',
+        description=(
+                "Ce endpoint permet de trouver un ou plusieurs bâtiments correspondant à une série de critères. "
+                "Il permet d'accueillir des données imprécises et tente de les combiner pour fournir le meilleur résultat."
+        ),
+        parameters=[
+            OpenApiParameter(
+                name='address',
+                description=(
+                        "Utilise les geocoders de la Base Adresse Nationale et d'Open Street Map pour tenter "
+                        "de géolocaliser l'adresse indiquée."
+                ),
+                required=False,
+                type=str,
+                examples=[
+                    OpenApiExample(
+                        "Exemple d'adresse",
+                        value="10 rue de la paix, Mérignac"
+                    )
+                ]
+            ),
+            OpenApiParameter(
+                name='name',
+                description=(
+                        "Utilise un geocoder Open Street Map pour tenter de géolocaliser le lieu donné."
+                ),
+                required=False,
+                type=str,
+                examples=[
+                    OpenApiExample(
+                        "Exemple de lieu",
+                        value="Notre Dame de Paris"
+                    )
+                ]
+            ),
+            OpenApiParameter(
+                name='point',
+                description=(
+                        "Favorise les bâtiments en fonction de leur position par rapport au point indiqué "
+                        "(latitude et longitude séparées par une virgule)."
+                ),
+                required=False,
+                type=str,
+                examples=[
+                    OpenApiExample(
+                        "Exemple de point",
+                        value="44.84114313595151,-0.5705289444867035"
+                    )
+                ]
+            ),
+            OpenApiParameter(
+                name='page',
+                description="Pagination des résultats de recherche.",
+                required=False,
+                type=int,
+                default=1,
+                examples=[
+                    OpenApiExample(
+                        "Page par défaut",
+                        value=1
+                    )
+                ]
+            )
+        ],
+        responses={
+            200: {
+                'description': 'Liste des bâtiments identifiés',
+                'content': {
+                    'application/json': {
+                        'example': [
+                            {
+                                "rnb_id": "QBAAG16VCJWA",
+                                "score": 0.753986390,
+                                "status": "constructed",
+                                "point": {
+                                    "type": "Point",
+                                    "coordinates": [
+                                        3.584410393780201,
+                                        49.52799819019749
+                                    ]
+                                },
+                                "addresses": [
+                                    {
+                                        "id": "02191_0020_00003",
+                                        "source": "bdnb",
+                                        "street_number": "3",
+                                        "street_rep": "",
+                                        "street_name": "de l'eglise",
+                                        "street_type": "rue",
+                                        "city_name": "Chivy-lès-Étouvelles",
+                                        "city_zipcode": "02000",
+                                        "city_insee_code": "02191"
+                                    }
+                                ],
+                                "ext_ids": [
+                                    {
+                                        "id": "bdnb-bc-3B85-TYM9-FDSX",
+                                        "source": "bdnb",
+                                        "created_at": "2023-12-07T13:20:58.310444+00:00",
+                                        "source_version": "2023_01"
+                                    }
+                                ]
+                            },
+                            {
+                                "rnb_id": "GT5Y98K4BV51",
+                                "score": 0.1405659,
+                                "status": "constructed",
+                                "point": {
+                                    "type": "Point",
+                                    "coordinates": [
+                                        6.269684,
+                                        43.89756654
+                                    ]
+                                },
+                                "addresses": [
+                                    {
+                                        "id": "02191_0020_00005",
+                                        "source": "bdnb",
+                                        "street_number": "5",
+                                        "street_rep": "",
+                                        "street_name": "de l'eglise",
+                                        "street_type": "rue",
+                                        "city_name": "Chivy-lès-Étouvelles",
+                                        "city_zipcode": "02000",
+                                        "city_insee_code": "02191"
+                                    }
+                                ],
+                                "ext_ids": [
+                                    {
+                                        "id": "bdnb-bc-3B86-TYM9-FRTS",
+                                        "source": "bdnb",
+                                        "created_at": "2023-12-07T13:25:58.310444+00:00",
+                                        "source_version": "2023_01"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            400: {
+                'description': 'Requête invalide'
+            },
+            404: {
+                'description': 'Bâtiment non trouvé'
+            }
+        }
+    )
     def get(self, request, *args, **kwargs):
         search = BuildingGuess()
         search.set_params_from_url(**request.query_params.dict())
@@ -333,6 +483,73 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
         """
         return super().list(request, *args, **kwargs)
 
+    @extend_schema(
+        operation_id='get_building',
+        summary='Consultation d\'un bâtiment',
+        description=(
+                "Ce endpoint permet de récupérer l'ensemble des attributs d'un bâtiment à partir de son identifiant RNB. "
+                "L'API renvoie les informations détaillées telles que l'ID du bâtiment, le statut, la géolocalisation, "
+                "les adresses associées et les identifiants externes."
+        ),
+        parameters=[
+            OpenApiParameter(
+                name='rnb_id',
+                description='Identifiant RNB du bâtiment',
+                required=True,
+                type=str
+            )
+        ],
+        responses={
+            200: {
+                'description': 'Détails du bâtiment',
+                'content': {
+                    'application/json': {
+                        'example': {
+                            "rnb_id": "QBAAG16VCJWA",
+                            "status": "constructed",
+                            "point": {
+                                "type": "Point",
+                                "coordinates": [
+                                    3.584410393780201,
+                                    49.52799819019749
+                                ]
+                            },
+                            "addresses": [
+                                {
+                                    "id": "02191_0020_00003",
+                                    "source": "bdnb",
+                                    "street_number": "3",
+                                    "street_rep": "",
+                                    "street_name": "de l'eglise",
+                                    "street_type": "rue",
+                                    "city_name": "Chivy-lès-Étouvelles",
+                                    "city_zipcode": "02000",
+                                    "city_insee_code": "02191"
+                                }
+                            ],
+                            "ext_ids": [
+                                {
+                                    "id": "bdnb-bc-3B85-TYM9-FDSX",
+                                    "source": "bdnb",
+                                    "created_at": "2023-12-07T13:20:58.310444+00:00",
+                                    "source_version": "2023_01"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            404: {
+                'description': 'Bâtiment non trouvé'
+            }
+        }
+    )
+    def retrieve(self, request, *args, **kwargs):
+        """
+        Renvoie les détails d'un bâtiment spécifique identifié par son RNB ID.
+        """
+        return super().retrieve(request, *args, **kwargs)
+
 
 class ADSBatchViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
     queryset = ADS.objects.all()
@@ -391,6 +608,94 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
     permission_classes = [ADSPermission]
     http_method_names = ["get", "post", "put", "delete"]
 
+    @extend_schema(
+        operation_id='list_ads',
+        summary='Liste et recherche d\'ADS',
+        description=(
+                "Cette API permet de lister et de rechercher des ADS (Autorisation de Droit de Sol). "
+                "Les requêtes doivent être authentifiées en utilisant un token. "
+                "Les filtres de recherche peuvent être passés en tant que paramètres d'URL."
+        ),
+        parameters=[
+            OpenApiParameter(name='q', description='Recherche parmi les n° de dossiers (file_number).', required=False, type=str),
+            OpenApiParameter(name='since', description='Récupère tous les dossiers décidés depuis cette date (AAAA-MM-DD).', required=False, type=str),
+        ],
+        responses={
+            200: OpenApiExample(
+                'Exemple de réponse',
+                value={
+                    "count": 3,
+                    "next": None,
+                    "previous": None,
+                    "results": [
+                        {
+                            "file_number": "TEST03818519U9999",
+                            "decided_at": "2023-06-01",
+                            "buildings_operations": [
+                                {
+                                    "rnb_id": "A1B2C3A1B2C3",
+                                    "shape": None,
+                                    "operation": "build"
+                                },
+                                {
+                                    "rnb_id": None,
+                                    "shape": {
+                                        "type": "Point",
+                                        "coordinates": [
+                                            5.722961565015281,
+                                            45.1851103238598
+                                        ]
+                                    },
+                                    "operation": "demolish"
+                                },
+                                {
+                                    "rnb_id": "1M2N3O1M2N3O",
+                                    "shape": {
+                                        "type": "Point",
+                                        "coordinates": [
+                                            5.723006573148693,
+                                            45.1851402293713
+                                        ]
+                                    },
+                                    "operation": "demolish"
+                                }
+                            ]
+                        },
+                        {
+                            "file_number": "PC3807123200WW",
+                            "decided_at": "2023-05-01",
+                            "buildings_operations": [
+                                {
+                                    "rnb_id": "FXFJZNZYGTED",
+                                    "shape": None,
+                                    "operation": "build"
+                                }
+                            ]
+                        },
+                        {
+                            "file_number": "PC384712301337",
+                            "decided_at": "2023-02-22",
+                            "buildings_operations": [
+                                {
+                                    "rnb_id": "RXNOSN2DUCLG",
+                                    "geometry": {
+                                        "type": "Point",
+                                        "coordinates": [
+                                            5.775791408470412,
+                                            45.256939624268206
+                                        ]
+                                    },
+                                    "operation": "modify"
+                                }
+                            ]
+                        },
+                    ]
+                },
+                response_only=True,
+                status_codes=['200']
+            )
+        }
+    )
     def get_queryset(self):
         search = ADSSearch(**self.request.query_params.dict())
 
@@ -399,7 +704,164 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
 
         return search.get_queryset()
 
+    @extend_schema(
+        operation_id='create_ads',
+        summary='Création d\'une ADS',
+        description=(
+                "Ce endpoint permet de créer une Autorisation du Droit des Sols (ADS) dans le RNB. "
+                "L'API ADS est réservée aux communes et requiert une authentification par token."
+        ),
+        request=ADSSerializer,
+        responses={
+            201: {
+                'description': 'ADS créée avec succès',
+                'content': {
+                    'application/json': {
+                        'example': {
+                            "file_number": "PCXXXXXXXXXX",
+                            "decided_at": "2019-03-18",
+                            "buildings_operations": [
+                                {
+                                    "operation": "demolish",
+                                    "rnb_id": "ABCD1234WXYZ",
+                                    "shape": None
+                                },
+                                {
+                                    "operation": "build",
+                                    "rnb_id": None,
+                                    "shape": {
+                                        "type": "Point",
+                                        "coordinates": [2.3552747458487002, 48.86958288638419]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            400: {
+                'description': 'Requête invalide'
+            }
+        }
+    )
+    def create(self, request, *args, **kwargs):
+        return super().create(request, *args, **kwargs)
 
+
+    @extend_schema(
+        operation_id='update_ads',
+        summary='Modification d\'une ADS',
+        description=(
+                "Ce endpoint permet de modifier une Autorisation du Droit des Sols (ADS) existante dans le RNB. "
+                "L'API ADS est réservée aux communes et requiert une authentification par token."
+        ),
+        request=ADSSerializer,
+        responses={
+            200: {
+                'description': 'ADS modifiée avec succès',
+                'content': {
+                    'application/json': {
+                        'example': {
+                            "file_number": "PCXXXXXXXXXX",
+                            "decided_at": "2019-03-10",
+                            "buildings_operations": [
+                                {
+                                    "operation": "demolish",
+                                    "rnb_id": "7865HG43PLS9",
+                                    "shape": None
+                                },
+                                {
+                                    "operation": "build",
+                                    "rnb_id": None,
+                                    "shape": {
+                                        "type": "Point",
+                                        "coordinates": [2.3552747458487002, 48.86958288638419]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            400: {
+                'description': 'Requête invalide'
+            },
+            404: {
+                'description': 'ADS non trouvée'
+            }
+        }
+    )
+    def update(self, request, *args, **kwargs):
+        return super().update(request, *args, **kwargs)
+
+    @extend_schema(
+        operation_id='delete_ads',
+        summary='Suppression d\'une ADS',
+        description='Ce endpoint permet de supprimer une Autorisation du Droit des Sols (ADS) existante dans le RNB.',
+        responses={
+            204: {
+                'description': 'ADS supprimée avec succès'
+            },
+            404: {
+                'description': 'ADS non trouvée'
+            }
+        }
+    )
+    def destroy(self, request, *args, **kwargs):
+        return super().destroy(request, *args, **kwargs)
+
+@extend_schema(
+    operation_id='get_vector_tiles',
+    summary='Obtenir des tuiles vectorielles',
+    description=(
+            "Cette API fournit des tuiles vectorielles au format PBF permettant d'intégrer les bâtiments "
+            "du Référentiel National des Bâtiments (RNB) dans une cartographie. Chaque tuile contient des points "
+            "représentant des bâtiments avec un attribut 'rnb_id'. Les tuiles sont utilisables avec un niveau de zoom "
+            "minimal de 16 et peuvent être intégrées dans des outils comme QGIS ou des sites web."
+    ),
+    parameters=[
+        {
+            'name': 'x',
+            'required': True,
+            'description': 'Coordonnée X de la tuile',
+            'schema': {
+                'type': 'integer'
+            }
+        },
+        {
+            'name': 'y',
+            'required': True,
+            'description': 'Coordonnée Y de la tuile',
+            'schema': {
+                'type': 'integer'
+            }
+        },
+        {
+            'name': 'z',
+            'required': True,
+            'description': 'Niveau de zoom de la tuile',
+            'schema': {
+                'type': 'integer'
+            }
+        }
+    ],
+    responses={
+        200: {
+            'content': {
+                'application/x-protobuf': {
+                    'schema': {
+                        'type': 'string',
+                        'format': 'binary'
+                    }
+                }
+            },
+            'description': 'Fichier PBF contenant les tuiles vectorielles'
+        },
+        400: {
+            'description': 'Requête invalide'
+        }
+    }
+)
 def get_tile_point(request, x, y, z):
     # Check the request zoom level
     if int(z) >= 16:

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -363,16 +363,14 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                 "bb",
                 str,
                 OpenApiParameter.QUERY,
-                description="""
-                    Filtre les bâtiments grâce à une bounding box.
-
-                    Le format est nw_lat,nw_lng,se_lat,se_lng avec :
-
-                    • nw_lat : latitude du point Nord Ouest
-                    • nw_lng : longitude du point Nord Ouest
-                    • se_lat : latitude du point Sud Est
-                    • se_lng : longitude du point Sud Est
-                """,
+                description=(
+                    "Filtre les bâtiments grâce à une bounding box.<br/>\n"
+                    "Le format est nw_lat,nw_lng,se_lat,se_lng avec :<br/>\n"
+                        "• nw_lat : latitude du point Nord Ouest<br/>\n"
+                        "• nw_lng : longitude du point Nord Ouest<br/>\n"
+                        "• se_lat : latitude du point Sud Est<br/>\n"
+                        "• se_lng : longitude du point Sud Est<br/>\n"
+                ),
                 examples=[
                     OpenApiExample(
                         "Exemple 1", value="48.845782,2.424525,48.839201,2.434158"
@@ -391,19 +389,16 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                     "constructionProject",
                     "canceledConstructionProject",
                 ],
-                description="""
-                    Filtre les bâtiments par statut.
-
-                    • constructed : Bâtiment construit
-                    • ongoingChange : En cours de modification
-                    • notUsable : Non utilisable (ex : une ruine)
-                    • demolished : Démoli
-
-                    Statuts réservés aux instructeurs d’autorisation du droit des sols.
-
-                    • constructionProject : Bâtiment en projet
-                    • canceledConstructionProject : Projet de bâtiment annulé
-                """,
+                description=(
+                        "Filtre les bâtiments par statut.<br/><br/>\n"
+                        "• constructed : Bâtiment construit<br/>\n"
+                        "• ongoingChange : En cours de modification<br/>\n"
+                        "• notUsable : Non utilisable (ex : une ruine)<br/>\n"
+                        "• demolished : Démoli<br/>\n"
+                        "Statuts réservés aux instructeurs d’autorisation du droit des sols.<br/><br/>\n"
+                        "• constructionProject : Bâtiment en projet<br/>\n"
+                        "• canceledConstructionProject : Projet de bâtiment annulé"
+                ),
                 examples=[
                     OpenApiExample(
                         "Exemple 1",
@@ -421,9 +416,7 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
                 "insee_code",
                 str,
                 OpenApiParameter.QUERY,
-                description="""
-                    Filtre les bâtiments grâce au code INSEE d'une commune.
-                     """,
+                description="Filtre les bâtiments grâce au code INSEE d'une commune.",
                 examples=[
                     OpenApiExample(
                         "Liste les bâtiments de la commune de Talence", value="33522"
@@ -1058,17 +1051,15 @@ def get_stats(request):
             "since",
             str,
             OpenApiParameter.QUERY,
-            description="""
-                Date et heure à partir de laquelle les modifications sont retournées.
-                Au format ISO 8601.
-
-                Si un "+" est présent dans la date, il doit être encodé en %2B.
-                2024-04-02 15:29:44.26+01 => 2024-04-02 15:29:44.26%2B01
-
-                Seules les dates après le 1er avril 2024 sont acceptées.
-                Une date inférieure reviendrait à télécharger l'intégralité de la base de données.
-                Ce qui peut être fait via https://www.data.gouv.fr/fr/datasets/referentiel-national-des-batiments/.
-            """,
+            description=(
+                "Date et heure à partir de laquelle les modifications sont retournées.<br/>\n"
+                "Au format ISO 8601.<br/><br/>\n"
+                "Si un \"+\" est présent dans la date, il doit être encodé en %2B.<br/>\n"
+                "2024-04-02 15:29:44.26+01 => 2024-04-02 15:29:44.26%2B01<br/><br/>\n"
+                "Seules les dates après le 1er avril 2024 sont acceptées.<br/>\n"
+                "Une date inférieure reviendrait à télécharger l'intégralité de la base de données.<br/>\n"
+                "Ce qui peut être fait via https://www.data.gouv.fr/fr/datasets/referentiel-national-des-batiments/.<br/>\n"
+            ),
             examples=[
                 OpenApiExample("Exemple 1", value="2024-04-02T00:00:00Z"),
                 OpenApiExample("Exemple 2", value="2024-04-02 15:29:44.267%2B01"),

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -352,7 +352,7 @@ class BuildingViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
     @extend_schema(
         tags=["Bâtiment"],
         operation_id="list_buildings",
-        summary="Listing de bâtiments",
+        summary="Liste et recherche de bâtiments",
         description=(
             "Ce endpoint permet de récupérer une liste paginée de bâtiments. "
             "Des filtres, notamment par code INSEE de la commune, sont disponibles."
@@ -756,7 +756,7 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
     @extend_schema(
         tags=["ADS"],
         operation_id="get_ads",
-        summary="Obtenir une ADS",
+        summary="Consultation d'une ADS",
         description=(
             "Cette API permet de récupérer une ADS (Autorisation de Droit de Sol). "
             "Les requêtes doivent être authentifiées en utilisant un token. "

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -1044,16 +1044,14 @@ def get_stats(request):
     tags=["Bâtiment"],
     operation_id="get_building_diff",
     summary="Obtenir les dernières modifications",
-    description="""
-        Filtre les modifications apportées au RNB ayant eu lieu strictement après un datetime.
-        Les données sont retournées au format CSV.
-
-        Les modifications listées sont de trois types : create, update et delete.
-
-        Les modifications sont triées par rnb_id puis par date de modification croissante.
-        Il est possible qu'un même bâtiment ait plusieurs modifications dans la période considérée.
-        Par exemple, une création (create) suivie d'une mise à jour (update).
-        """,
+    description=(
+        "Filtre les modifications apportées au RNB ayant eu lieu strictement après un datetime. "
+        "Les données sont retournées au format CSV. "
+        "Les modifications listées sont de trois types : create, update et delete. "
+        "Les modifications sont triées par rnb_id puis par date de modification croissante. "
+        "Il est possible qu'un même bâtiment ait plusieurs modifications dans la période considérée. "
+        "Par exemple, une création (create) suivie d'une mise à jour (update). "
+    ),
     auth=[],
     parameters=[
         OpenApiParameter(

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -163,10 +163,12 @@ REST_FRAMEWORK = {
 }
 
 SPECTACULAR_SETTINGS = {
-    'TITLE': 'Documentation de l\'API du Référentiel National du Bâtiment (RNB)',
-    'VERSION': '1.0.0',
-    'SECURITY': [],
-    'PREPROCESSING_HOOKS': ["api_alpha.utils.drf_spectacular_extension.filter_endpoints_hook"]
+    "TITLE": "Documentation de l'API du Référentiel National du Bâtiment (RNB)",
+    "VERSION": "1.0.0",
+    "SECURITY": [],
+    "PREPROCESSING_HOOKS": [
+        "api_alpha.utils.drf_spectacular_extension.filter_endpoints_hook"
+    ],
 }
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -164,7 +164,7 @@ REST_FRAMEWORK = {
 
 SPECTACULAR_SETTINGS = {
     "TITLE": "Documentation de l'API du Référentiel National du Bâtiment (RNB)",
-    "VERSION": "1.0.0",
+    "VERSION": "0.0.1",
     "SECURITY": [],
     "PREPROCESSING_HOOKS": [
         "api_alpha.utils.drf_spectacular_extension.filter_endpoints_hook"

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -162,6 +162,13 @@ REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
 
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Documentation de l\'API du Référentiel National du Bâtiment (RNB)',
+    'VERSION': '1.0.0',
+    'SECURITY': [],
+    'PREPROCESSING_HOOKS': ["api_alpha.utils.drf_spectacular_extension.filter_endpoints_hook"]
+}
+
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Internationalization

--- a/app/batid/apps.py
+++ b/app/batid/apps.py
@@ -7,3 +7,4 @@ class BatidConfig(AppConfig):
 
     def ready(self):
         from batid.signals import receivers  # noqa
+        from api_alpha.utils import drf_spectacular_extension  # noqa


### PR DESCRIPTION
Afin de document nos APIs via la génération d'une documentation "code first", cette PR ajoute les annotations `@extend_schema` de DRF Spectacular afin de compléter les informations manquantes issues du Gitbook (https://rnb-fr.gitbook.io/documentation).