### PR TITLE
Lien export des ADS

### DIFF
--- a/app/batid/admin.py
+++ b/app/batid/admin.py
@@ -6,7 +6,9 @@ from batid.models import Address
 from batid.models import ADS
 from batid.models import Contribution
 from batid.models import Organization
-from batid.views import worker
+from batid.views import worker, export_ads
+
+from django.contrib.admin.views.decorators import staff_member_required
 
 
 class OrganizationAdmin(admin.ModelAdmin):
@@ -66,7 +68,10 @@ admin.site.register(ADS, ADSAdmin)
 
 def get_admin_urls(urls):
     def get_urls():
-        my_urls = [path(r"worker/", admin.site.admin_view(worker))]
+        my_urls = [
+            path(r"worker/", admin.site.admin_view(worker)),
+            path(r"export_ads/", export_ads),
+        ]
         return my_urls + urls
 
     return get_urls

--- a/app/batid/admin.py
+++ b/app/batid/admin.py
@@ -6,9 +6,8 @@ from batid.models import Address
 from batid.models import ADS
 from batid.models import Contribution
 from batid.models import Organization
-from batid.views import worker, export_ads
-
-from django.contrib.admin.views.decorators import staff_member_required
+from batid.views import export_ads
+from batid.views import worker
 
 
 class OrganizationAdmin(admin.ModelAdmin):

--- a/app/batid/services/ads.py
+++ b/app/batid/services/ads.py
@@ -1,11 +1,9 @@
-import csv
-from io import StringIO
-
 from django.contrib.auth.models import User
 from django.contrib.gis.geos import GEOSGeometry
 from django.db import connection
 
-from batid.models import ADS, BuildingADS
+from batid.models import ADS
+from batid.models import BuildingADS
 from batid.models import City
 from batid.utils.db import dictfetchall
 

--- a/app/batid/services/ads.py
+++ b/app/batid/services/ads.py
@@ -1,8 +1,13 @@
+import csv
+from io import StringIO
+
 from django.contrib.auth.models import User
 from django.contrib.gis.geos import GEOSGeometry
+from django.db import connection
 
-from batid.models import ADS
+from batid.models import ADS, BuildingADS
 from batid.models import City
+from batid.utils.db import dictfetchall
 
 
 def get_managed_insee_codes(user: User) -> list:
@@ -80,3 +85,23 @@ def get_cities(rnb_ids: list, geojson_geometries: list[GEOSGeometry]) -> list:
     cities = City.objects.raw(q, params)
 
     return [c for c in cities]
+
+
+class CsvDictWriter:
+    pass
+
+
+def export_format() -> list:
+
+    q = (
+        "SELECT ads.*, ads_bdg.rnb_id, ST_AsText(ads_bdg.shape) as shape, ads_bdg.operation, u.id as user_id, u.username, u.email "
+        f"FROM {ADS._meta.db_table} as ads "
+        f"left join {BuildingADS._meta.db_table} as ads_bdg on ads.id = ads_bdg.ads_id "
+        f"left join {User._meta.db_table} as u on u.id = ads.creator_id "
+        "order by id desc"
+    )
+
+    with connection.cursor() as cursor:
+        data = dictfetchall(cursor, q)
+
+    return data

--- a/app/batid/views.py
+++ b/app/batid/views.py
@@ -2,7 +2,7 @@ import os
 
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.db import transaction
-from django.http import HttpResponseBadRequest
+from django.http import HttpResponseBadRequest, HttpResponse
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404
 from django.shortcuts import render
@@ -25,6 +25,11 @@ def worker(request):
             "active_tasks": active_tasks,
         },
     )
+
+
+def export_ads(request):
+
+    return HttpResponse("Exporting ADS")
 
 
 class FlowerProxyView(UserPassesTestMixin, ProxyView):

--- a/app/batid/views.py
+++ b/app/batid/views.py
@@ -1,5 +1,6 @@
 import os
 
+from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.db import transaction
 from django.http import HttpResponseBadRequest, HttpResponse
@@ -27,6 +28,7 @@ def worker(request):
     )
 
 
+@staff_member_required
 def export_ads(request):
 
     return HttpResponse("Exporting ADS")

--- a/app/batid/views.py
+++ b/app/batid/views.py
@@ -5,7 +5,8 @@ from io import StringIO
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.db import transaction
-from django.http import HttpResponseBadRequest, HttpResponse
+from django.http import HttpResponse
+from django.http import HttpResponseBadRequest
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404
 from django.shortcuts import render

--- a/app/batid/views.py
+++ b/app/batid/views.py
@@ -1,4 +1,6 @@
+import csv
 import os
+from io import StringIO
 
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.mixins import UserPassesTestMixin
@@ -13,6 +15,7 @@ from revproxy.views import ProxyView
 from app.celery import app as celery_app
 from batid.models import Building
 from batid.models import Contribution
+from batid.services.ads import export_format
 
 
 def worker(request):
@@ -31,7 +34,20 @@ def worker(request):
 @staff_member_required
 def export_ads(request):
 
-    return HttpResponse("Exporting ADS")
+    data = export_format()
+
+    csv_f = StringIO()
+    csv_writer = csv.DictWriter(csv_f, fieldnames=data[0].keys())
+    csv_writer.writeheader()
+    csv_writer.writerows(data)
+    csv_f.seek(0)
+
+    return HttpResponse(
+        csv_f,
+        content_type="text/csv",
+        status=200,
+        headers={"Content-Disposition": 'attachment; filename="export_ads.csv"'},
+    )
 
 
 class FlowerProxyView(UserPassesTestMixin, ProxyView):


### PR DESCRIPTION
On a besoin de régulièrement exporter les ADS pour en faire des stats. On ajoute ce lien à la liste des ADS dans le backoffice de Django.