### PR TITLE
Hotfix : export contributions

### DIFF
--- a/app/batid/management/commands/sandbox.py
+++ b/app/batid/management/commands/sandbox.py
@@ -1,6 +1,12 @@
+import csv
+from io import StringIO
+
 from django.core.management.base import BaseCommand
+
+from batid.services.contributions import export_format
 
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
+
         pass

--- a/app/batid/services/contributions.py
+++ b/app/batid/services/contributions.py
@@ -1,11 +1,11 @@
 from django.db import connection
 
 from batid.models import Contribution
+from batid.utils.db import dictfetchall
 
 
 def export_format() -> list:
 
     q = f"SELECT * FROM {Contribution._meta.db_table} ORDER BY created_at DESC"
     with connection.cursor() as cursor:
-        cursor.execute(q)
-        return cursor.fetchall()
+        return dictfetchall(cursor, q)


### PR DESCRIPTION
Utilisation de `dictfetchall` pour récupération des données au bon format.