### PR TITLE
Gestion des candidats souffrant du bug GEOS

### DIFF
--- a/app/batid/management/commands/sandbox.py
+++ b/app/batid/management/commands/sandbox.py
@@ -6,30 +6,4 @@ from django.core.management.base import BaseCommand
 class Command(BaseCommand):
     def handle(self, *args, **options):
 
-        wkt_1 = "POLYGON ((1.839012980156925 43.169860517728324, 1.838983490127865 43.169860200336274, 1.838898525601717 43.169868281549725, 1.838918565176068 43.1699719478626, 1.838920733577112 43.16998636433192, 1.838978629555589 43.16997979090823, 1.838982586839382 43.169966339940714, 1.838974943184281 43.169918580432174, 1.839020497362873 43.169914572864634, 1.839012980156925 43.169860517728324))"
-        wkt_2 = "POLYGON ((1.8391355300979277 43.16987802887805, 1.83913336164737 43.16986361241434, 1.8390129801569248 43.169860517728324, 1.8390790978572837 43.16987292371998, 1.8390909520103162 43.16995581178317, 1.8391377530291442 43.16995091801345, 1.8391293863398452 43.16987796276235, 1.8391355300979277 43.16987802887805))"
-
-        # Problematic case
-        # This triggers error
-        p1 = GEOSGeometry(wkt_1)
-        p2 = GEOSGeometry(wkt_2)
-
-        # p1.intersects(p2)
-
-        q = "Select ST_Intersects(ST_GeomFromText(%s), ST_GeomFromText(%s))"
-        from django.db import connection
-
-        with connection.cursor() as cursor:
-
-            try:
-                cursor.execute(q, [wkt_1, wkt_2])
-                cursor.fetchall()
-            except django.db.utils.InternalError as e:
-                print("internal error")
-
-                if "TopologyException: side location conflict" in str(e):
-                    print("We got it")
-
-                print(e)
-                print(type(e))
-                print("Error<<<")
+        pass

--- a/app/batid/management/commands/sandbox.py
+++ b/app/batid/management/commands/sandbox.py
@@ -1,5 +1,3 @@
-import django.db.utils
-from django.contrib.gis.geos import GEOSGeometry
 from django.core.management.base import BaseCommand
 
 

--- a/app/batid/services/candidate.py
+++ b/app/batid/services/candidate.py
@@ -40,6 +40,8 @@ class Inspector:
                     self.get_matching_bdgs()
                     self.inspect_candidate()
         except Exception as e:
+            # We intercept the topology exception to avoid the task to crash
+            # bug description : https://gis.stackexchange.com/questions/484691/topologyexception-side-location-conflict-while-intersects-on-valid-polygons
             if "TopologyException: side location conflict" in str(e):
                 self.decide_refusal_topology_exception()
             else:

--- a/app/batid/tests/test_inspector.py
+++ b/app/batid/tests/test_inspector.py
@@ -1,10 +1,12 @@
 import json
 from datetime import datetime
 
+import psycopg2
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.geos import Point
 from django.contrib.gis.geos import Polygon
-from django.db.utils import IntegrityError
+from django.db import connection, transaction
+from django.db.utils import IntegrityError, InternalError
 from django.test import TestCase
 from django.test import TransactionTestCase
 
@@ -919,3 +921,56 @@ class NonExistingAddress(TransactionTestCase):
         # check the candidate inspection_details is properly reverted
         self.assertFalse(candidate.inspection_details)
         self.assertFalse(candidate.inspected_at)
+
+
+class GeosIntersectsBugInterception(TransactionTestCase):
+
+    WKT_1 = "POLYGON ((1.839012980156925 43.169860517728324, 1.838983490127865 43.169860200336274, 1.838898525601717 43.169868281549725, 1.838918565176068 43.1699719478626, 1.838920733577112 43.16998636433192, 1.838978629555589 43.16997979090823, 1.838982586839382 43.169966339940714, 1.838974943184281 43.169918580432174, 1.839020497362873 43.169914572864634, 1.839012980156925 43.169860517728324))"
+    WKT_2 = "POLYGON ((1.8391355300979277 43.16987802887805, 1.83913336164737 43.16986361241434, 1.8390129801569248 43.169860517728324, 1.8390790978572837 43.16987292371998, 1.8390909520103162 43.16995581178317, 1.8391377530291442 43.16995091801345, 1.8391293863398452 43.16987796276235, 1.8391355300979277 43.16987802887805))"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.buggy_geos = False
+
+    def setUp(self):
+        """
+        We do not have full control over GEOS version (our production db is managed)
+        The bug appears on GEOS 3.11 but not on GEOS 3.9 and seems to be fixed on 3.12
+        We first have to check if the bug is present, then we can test the interception
+        """
+        with transaction.atomic():
+            with connection.cursor() as cursor:
+                try:
+                    cursor.execute(
+                        "SELECT ST_Intersects(ST_GeomFromText(%s), ST_GeomFromText(%s))",
+                        [self.WKT_1, self.WKT_2],
+                    )
+                    cursor.fetchone()
+                except Exception as e:
+                    if "TopologyException: side location conflict" in str(e):
+                        self.buggy_geos = True
+
+    def test_interception(self):
+
+        if self.buggy_geos:
+
+            print("GEOS is buggy, we do the skip test")
+
+            bdg_geom = GEOSGeometry(self.WKT_1)
+            Building.objects.create(
+                rnb_id="BUGGY", shape=bdg_geom, point=bdg_geom.point_on_surface
+            )
+
+            candidate_geom = GEOSGeometry(self.WKT_2)
+            Candidate.objects.create(
+                shape=candidate_geom,
+                is_light=False,
+            )
+
+            i = Inspector()
+            i.inspect()
+
+            c = Candidate.objects.all().first()
+            self.assertEqual(c.inspection_details["decision"], "refusal")
+            self.assertEqual(c.inspection_details["reason"], "topology_exception")
+            self.assertNotEqual(c.inspected_at, None)


### PR DESCRIPTION
Nous avons des candidats qui ne peuvent être correctement inspectés du fait d'un bug présent dans GEOS 3.11. Le problème est décrit dans ctte question [GIS Stackexchange](https://gis.stackexchange.com/questions/484691/topologyexception-side-location-conflict-while-intersects-on-valid-polygons?noredirect=1#comment790715_484691).

Quand le candidat souffre de bug, nous interceptons l'exception et indiquons que ce candidat a été refusé et attachons la raison `topology_exception`.

Il s'agira de reprendre ces candidats une fois que nous serons passé à une version de GEOS sans bug (la 3.12).