### PR TITLE
Update nginx docker containers

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -16,7 +16,7 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
 
   nginx-letsencrypt:
-    image: jrcs/letsencrypt-nginx-proxy-companion
+    image: nginxproxy/acme-companion:2.5.0
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,3 +1,3 @@
-FROM jwilder/nginx-proxy:0.9
+FROM jwilder/nginx-proxy:1.6.1
 # COPY vhost.d/default /etc/nginx/vhost.d/default
 COPY custom.conf /etc/nginx/conf.d/custom.conf


### PR DESCRIPTION
Notre config docker avait mal vieilli, et il était devenu impossible de remettre sur pieds un serveur pour notre application (suite à un [breaking change](https://github.com/nginx-proxy/acme-companion/releases/tag/v2.4.0) de la version 2.4.0 de nginxproxy/acme-companion, et au fait que nous tirions d'un cote le container nginx avec une version fixée et ancienne, mais acme-companion en `latest`.

⚠️ : NE PAS MERGER, CA RISQUE DE CASSER LA PROD QUI NE PEUT PLUS BUILDER DE NOUVELLES IMAGES