### PR TITLE
Doublons : fix

### DIFF
--- a/app/batid/services/data_fix/remove_light_buildings.py
+++ b/app/batid/services/data_fix/remove_light_buildings.py
@@ -86,40 +86,48 @@ def buildings_to_remove(bd_topo_path, max_workers=50):
         matching_rnb_ids = []
 
         for rnb_id in rnb_ids_list:
-            sql = f"""
-                with contained as (
-                select
-                    ST_AREA(ST_INTERSECTION(bb.shape,
-                    ST_GeomFromText('{geometry}', 4326))) / NULLIF(ST_AREA(bb.shape), 0) > 0.9 as contained,
-                    ST_AREA(bb.shape, False) as surface
-                from
-                    batid_building bb
-                where
-                    bb.rnb_id = '{rnb_id}')
-                , neighbors as (
-                select
-                    count(bb.rnb_id) as count
-                from
-                    batid_building bb
-                left join batid_building bb2 on
-                    true
-                where
-                    bb2.rnb_id = '{rnb_id}'
-                    and bb.rnb_id != '{rnb_id}'
-                    and ST_DWITHIN(bb.shape, bb2.shape, 0.0)
-                ) select contained, count, surface from contained, neighbors;
-            """
+            try:
+                sql = f"""
+                    with contained as (
+                    select
+                        ST_AREA(ST_INTERSECTION(bb.shape,
+                        ST_GeomFromText('{geometry}', 4326))) / NULLIF(ST_AREA(bb.shape), 0) > 0.9 as contained,
+                        ST_AREA(bb.shape, False) as surface
+                    from
+                        batid_building bb
+                    where
+                        bb.rnb_id = '{rnb_id}')
+                    , neighbors as (
+                    select
+                        count(bb.rnb_id) as count
+                    from
+                        batid_building bb
+                    left join batid_building bb2 on
+                        true
+                    where
+                        bb2.rnb_id = '{rnb_id}'
+                        and bb.rnb_id != '{rnb_id}'
+                        and ST_DWITHIN(bb.shape, bb2.shape, 0.0)
+                    ) select contained, count, surface from contained, neighbors;
+                """
 
-            cursor.execute(sql)
-            results = cursor.fetchone()
+                cursor.execute(sql)
+                results = cursor.fetchone()
 
-            if results and results[0] and results[1] > 0 and results[2] < 40:
-                # rnb is contained in bd topo building + has neighbor(s) + has a small (<40m²) surface
-                # explanation:
-                #   - stand alone light buildings are more likely to be real buildings
-                #   - big buildings are more likely to be real buildings
-                #   - we prefer to miss some buildings during the cleaning, than over cleaning.
-                matching_rnb_ids.append(rnb_id)
+                if results and results[0] and results[1] > 0 and results[2] < 40:
+                    # rnb is contained in bd topo building + has neighbor(s) + has a small (<40m²) surface
+                    # explanation:
+                    #   - stand alone light buildings are more likely to be real buildings
+                    #   - big buildings are more likely to be real buildings
+                    #   - we prefer to miss some buildings during the cleaning, than over cleaning.
+                    matching_rnb_ids.append(rnb_id)
+            except Exception as e:
+                # sometimes the SQL request crashes because the computed surface area is negative
+                # we would like to know more about those buildings
+                print(f"issue with rnb_id {rnb_id}, skipping this building {repr(e)}")
+                with open("log_error_surface.csv", "w") as f:
+                    f.write(f"{rnb_id}\n")
+                continue
 
         return matching_rnb_ids
 


### PR DESCRIPTION
On a des crashs sur certains départements à cause d'une erreur sur le calcul de la surface.

"lwgeom_area_spher(oid) returned area < 0.0"

Je pense que ces cas sont rares, je vais sauter les buildings concernés par le problème et noter leur rnb_id dans un fichier à part, quitte à y revenir par la suite.