### PR TITLE
Endpoints de lecture des ADS publics

### DIFF
--- a/app/api_alpha/permissions.py
+++ b/app/api_alpha/permissions.py
@@ -15,17 +15,28 @@ class ADSPermission(permissions.DjangoModelPermissions):
 
     def has_permission(self, request, view):
 
+        # Everybody can list and retrieve ADS
+        if view.action in ['list', 'retrieve']:
+            return True
+
+        # For others actions, we need to be authenticated and have the rights
         return request.user.is_authenticated and super().has_permission(request, view)
 
     def has_object_permission(self, request, view, obj):
 
+        # You are superuser? Please, be our guest
+        # Superuser -> all permissions
+        if request.user.is_authenticated and request.user.is_superuser:
+            return True
+
+        # Everybody can read ADS
+        if view.action in ['retrieve']:
+            return True
+
+        # For others actions, we need to be authenticated and have the rights
         # Not authenticated users -> no permission
         if not request.user.is_authenticated:
             return False
-
-        # Super user -> all permissions
-        if request.user.is_authenticated and request.user.is_superuser:
-            return True
 
         # User does not have permission to perform this action (DjangoModelPermissions) -> no permission
         if not super().has_object_permission(request, view, obj):

--- a/app/api_alpha/permissions.py
+++ b/app/api_alpha/permissions.py
@@ -16,7 +16,7 @@ class ADSPermission(permissions.DjangoModelPermissions):
     def has_permission(self, request, view):
 
         # Everybody can list and retrieve ADS
-        if view.action in ['list', 'retrieve']:
+        if view.action in ["list", "retrieve"]:
             return True
 
         # For others actions, we need to be authenticated and have the rights
@@ -30,7 +30,7 @@ class ADSPermission(permissions.DjangoModelPermissions):
             return True
 
         # Everybody can read ADS
-        if view.action in ['retrieve']:
+        if view.action in ["retrieve"]:
             return True
 
         # For others actions, we need to be authenticated and have the rights

--- a/app/api_alpha/tests/test_ads.py
+++ b/app/api_alpha/tests/test_ads.py
@@ -223,7 +223,7 @@ class ADSEnpointsWithBadAuthTest(APITestCase):
         r = self.client.get(
             "/api/alpha/ads/ADS-GRENOBLE/", content_type="application/json"
         )
-        self.assertEqual(r.status_code, 403)
+        self.assertEqual(r.status_code, 200)
 
 
 class ADSEndpointsWithAuthTest(APITestCase):
@@ -1325,11 +1325,11 @@ class ADSEnpointsNoAuthTest(APITestCase):
 
     def test_ads_root(self):
         r = self.client.get("/api/alpha/ads/")
-        self.assertEqual(r.status_code, 401)
+        self.assertEqual(r.status_code, 200)
 
     def test_ads_detail(self):
         r = self.client.get("/api/alpha/ads/ADS-TEST-UPDATE-BDG/")
-        self.assertEqual(r.status_code, 401)
+        self.assertEqual(r.status_code, 200)
 
     def test_ads_cant_delete(self):
         r = self.client.delete("/api/alpha/ads/ADS-TEST-DELETE/")


### PR DESCRIPTION
J'ai modifié la vérification des permissions pour rendre les endpoints de consultation et de listing d'ADS publics.

Les tests sont adaptés en conséquence.