### PR TITLE
Ne pas autoriser d'opérations sur des batiments inactifs

### DIFF
--- a/app/batid/models.py
+++ b/app/batid/models.py
@@ -153,23 +153,29 @@ class Building(BuildingAbstract):
         It is not expected to hard delete anything in the RNB, as it would break our capacity to audit its history.
         This soft delete method is used to mark a building as inactive, with an event_type "delete"
         """
-        self.event_type = "delete"
-        self.is_active = False
-        self.event_id = uuid.uuid4()
-        self.event_user = user
-        self.event_origin = event_origin
-        self.save()
+        if self.is_active:
+            self.event_type = "delete"
+            self.is_active = False
+            self.event_id = uuid.uuid4()
+            self.event_user = user
+            self.event_origin = event_origin
+            self.save()
 
-        self._refuse_pending_contributions(user)
+            self._refuse_pending_contributions(user)
+        else:
+            print(f"Cannot soft-delete an inactive building: {self.rnb_id}")
 
     def update(self, user, event_origin, status, addresses_id):
-        self.event_type = "update"
-        self.event_id = uuid.uuid4()
-        self.event_user = user
-        self.event_origin = event_origin
-        self.addresses_id = addresses_id
-        self.status = status
-        self.save()
+        if self.is_active:
+            self.event_type = "update"
+            self.event_id = uuid.uuid4()
+            self.event_user = user
+            self.event_origin = event_origin
+            self.addresses_id = addresses_id
+            self.status = status
+            self.save()
+        else:
+            print(f"Cannot update an inactive building: {self.rnb_id}")
 
     def _refuse_pending_contributions(self, user: User):
 

--- a/app/batid/tests/test_models.py
+++ b/app/batid/tests/test_models.py
@@ -119,11 +119,27 @@ class TestBuilding(TestCase):
         bdg.soft_delete(user, {"k": "v"})
         bdg.refresh_from_db()
 
-        self.assertEqual(bdg.is_active, False)
+        self.assertFalse(bdg.is_active)
         self.assertEqual(bdg.event_user, user)
         self.assertEqual(bdg.event_type, "delete")
         self.assertEqual(bdg.event_origin, {"k": "v"})
         self.assertIsNotNone(bdg.event_id)
+
+    def test_no_soft_delete_inactive_buildings(self):
+        """
+        An inactive building soft-delete is ignored.
+        """
+        bdg = Building.objects.create(rnb_id="AAA", shape="POINT(0 0)", is_active=False)
+        user = User.objects.create_user(username="dummy")
+        bdg.soft_delete(user, {"k": "v"})
+        bdg.refresh_from_db()
+
+        # nothing has changed
+        self.assertFalse(bdg.is_active)
+        self.assertIsNone(bdg.event_user)
+        self.assertIsNone(bdg.event_type)
+        self.assertIsNone(bdg.event_origin)
+        self.assertIsNone(bdg.event_id)
 
     def test_soft_delete_with_contributions(self):
         """


### PR DESCRIPTION
Je n'ai pas envie qu'on puisse `soft_delete` un batiment qui est deja inactif, ni de le mettre à jour.