### PR TITLE
Nouveaux endpoints pour ADS

### DIFF
--- a/app/api_alpha/tests/test_ads.py
+++ b/app/api_alpha/tests/test_ads.py
@@ -1317,7 +1317,7 @@ class ADSEndpointsWithAuthTest(APITestCase):
 
 class ADSEnpointsNoAuthTest(APITestCase):
     def setUp(self) -> None:
-        grenoble = create_grenoble()
+        create_grenoble()
 
         ADS.objects.create(file_number="ADS-TEST-UPDATE-BDG", decided_at="2025-01-01")
 
@@ -1335,3 +1335,15 @@ class ADSEnpointsNoAuthTest(APITestCase):
         r = self.client.delete("/api/alpha/ads/ADS-TEST-DELETE/")
 
         self.assertEqual(r.status_code, 401)
+
+
+    # Adblockers are blocking requests where "ads" is in the URL
+    # We created a new endpoint to provide the ADS data on the website
+
+    def test_permis_root(self):
+        r = self.client.get("/api/alpha/permis/")
+        self.assertEqual(r.status_code, 200)
+
+    def test_permis_detail(self):
+        r = self.client.get("/api/alpha/permis/ADS-TEST-UPDATE-BDG/")
+        self.assertEqual(r.status_code, 200)

--- a/app/api_alpha/urls.py
+++ b/app/api_alpha/urls.py
@@ -3,7 +3,7 @@ from django.urls import path
 from rest_framework import routers
 from rest_framework.authtoken import views as auth_views
 
-from api_alpha.views import AdsTokenView
+from api_alpha.views import AdsTokenView, PermisViewSet
 from api_alpha.views import ADSVectorTileView
 from api_alpha.views import ADSViewSet
 from api_alpha.views import BuildingClosestView
@@ -21,8 +21,8 @@ router = routers.DefaultRouter()
 # router.register(r"buildings/guess", BuildingGuessView, basename="guess")
 router.register(r"contributions", ContributionsViewSet)
 router.register(r"buildings", BuildingViewSet)
-# router.register(r"ads/batch", ADSBatchViewSet)
 router.register(r"ads", ADSViewSet)
+
 
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
@@ -35,9 +35,25 @@ urlpatterns = [
     path("buildings/diff/", DiffView.as_view()),
     path("ads/token/", AdsTokenView.as_view()),
     path("ads/tiles/<int:x>/<int:y>/<int:z>.pbf", ADSVectorTileView.as_view()),
-    path("", include(router.urls)),
     path("login/", auth_views.obtain_auth_token),
     path("tiles/<int:x>/<int:y>/<int:z>.pbf", BuildingsVectorTileView.as_view()),
     path("tiles/shapes/<int:x>/<int:y>/<int:z>.pbf", get_tile_shape),
     # path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+
 ]
+
+
+# The /ads/ prefix is blocked by the adblockers
+# We create two sets of URLs to serve ADS on urls without /ads/ prefix
+# They will be used on the website but do not have to be in the documentation
+urlpatterns.append(path("permis/tiles/<int:x>/<int:y>/<int:z>.pbf", ADSVectorTileView.as_view()))
+router.register(r"permis", ADSViewSet, basename="permis")
+
+# Add the router URLs to the urlpatterns
+urlpatterns.append(path("", include(router.urls)))
+
+
+
+
+
+

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -505,6 +505,7 @@ class ADSBatchViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
             raise ParseError({"errors": "No data in the request."})
 
 
+
 class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
     queryset = ADS.objects.all()
     serializer_class = ADSSerializer
@@ -795,6 +796,10 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
     )
     def destroy(self, request, *args, **kwargs):
         return super().destroy(request, *args, **kwargs)
+
+
+class PermisViewSet(ADSViewSet):
+    pass
 
 
 class ADSVectorTileView(APIView):

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -796,6 +796,7 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
     def destroy(self, request, *args, **kwargs):
         return super().destroy(request, *args, **kwargs)
 
+
 class ADSVectorTileView(APIView):
     def get(self, request, x, y, z):
 

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -797,11 +797,6 @@ class ADSViewSet(RNBLoggingMixin, viewsets.ModelViewSet):
     def destroy(self, request, *args, **kwargs):
         return super().destroy(request, *args, **kwargs)
 
-
-class PermisViewSet(ADSViewSet):
-    pass
-
-
 class ADSVectorTileView(APIView):
     def get(self, request, x, y, z):
 


### PR DESCRIPTION
Les bloqueurs de pubs nous posent des problèmes pour l'affichage des ADS sur notre carte. Ils bloquent les appels aux urls contenant ADS et empêchent donc qu'on puisse obtenir les détails d'une ADS via des `https://rnb-api.beta.gouv.fr/api/alpha/**ads**/[file_number]/`

Pour parer à cela, on créé des urls miroirs des endpoints ADS et des urls des tuiles vectorielles des ADS. Elle contiennent `permis` à la place d'`ads`.

Les autres urls (celles contenant `/ads/`) continuent d'être nos urls "officielles".

Les urls `/permis/` n'ont pas vocation à être diffusées ou documentées.

