### PR TITLE
Réparation endpoint signalement

### DIFF
--- a/app/api_alpha/tests/test_views.py
+++ b/app/api_alpha/tests/test_views.py
@@ -289,7 +289,7 @@ class ContributionTest(APITestCase):
         r = self.client.post("/api/alpha/contributions/", data)
 
         self.assertEqual(r.status_code, 201)
-        self.assertEqual(Contribution.objects.count(), 5)
+        self.assertEqual(Contribution.objects.count(), 2)
         # loulou is expected at the second place, ex aequo with fifi
         self.assertEqual(
             r.json(),

--- a/app/api_alpha/tests/test_views.py
+++ b/app/api_alpha/tests/test_views.py
@@ -281,19 +281,12 @@ class DiffTest(TransactionTestCase):
 
 class ContributionTest(APITestCase):
     def test_contribution(self):
+
         Building.objects.create(rnb_id="1")
-        Building.objects.create(rnb_id="2")
-        Building.objects.create(rnb_id="3")
-
         Contribution.objects.create(rnb_id="1", text="", email="riri@email.fr")
-        Contribution.objects.create(rnb_id="2", text="", email="riri@email.fr")
-        Contribution.objects.create(rnb_id="3", text="", email="riri@email.fr")
-
-        Contribution.objects.create(rnb_id="1", text="", email="fifi@email.fr")
 
         data = {"email": "loulou@email.fr", "text": "test", "rnb_id": "1"}
-
-        r = self.client.post("/api/alpha/contributions/?ranking=true", data)
+        r = self.client.post("/api/alpha/contributions/", data)
 
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Contribution.objects.count(), 5)
@@ -304,140 +297,119 @@ class ContributionTest(APITestCase):
                 "rnb_id": "1",
                 "text": "test",
                 "email": "loulou@email.fr",
-                "contributor_count": 1,
-                "contributor_rank": 2,
             },
         )
 
-        self.client.post("/api/alpha/contributions/?ranking=true", data)
-        r = self.client.post("/api/alpha/contributions/?ranking=true", data)
-        # two contributions later, loulou is now first ex aequo with riri
-        self.assertEqual(Contribution.objects.count(), 7)
-        self.assertEqual(
-            r.json(),
-            {
-                "rnb_id": "1",
-                "text": "test",
-                "email": "loulou@email.fr",
-                "contributor_count": 3,
-                "contributor_rank": 1,
-            },
-        )
 
-        # contribution without ranking in response
-        r = self.client.post("/api/alpha/contributions/", data)
-        self.assertEqual(
-            r.json(), {"rnb_id": "1", "text": "test", "email": "loulou@email.fr"}
-        )
 
-    @freeze_time("2024-08-05")
-    def test_ranking(self):
-        from batid.models import Department_subdivided
-
-        create_grenoble()
-        create_paris()
-
-        Department_subdivided.objects.create(
-            code="75",
-            name="Paris",
-            shape=GEOSGeometry(
-                json.dumps(
-                    {
-                        "coordinates": [
-                            [
-                                [2.353306071148694, 48.90085197679912],
-                                [2.298936023110457, 48.89580357010155],
-                                [2.273133288448662, 48.87419062799353],
-                                [2.2602319211170823, 48.84630219945575],
-                                [2.313373267504062, 48.82102752865572],
-                                [2.372965297558153, 48.81678013291423],
-                                [2.4175057323916462, 48.84407854008418],
-                                [2.411362224139367, 48.878837188722514],
-                                [2.3907814714921187, 48.89964040569237],
-                                [2.353306071148694, 48.90085197679912],
-                            ]
-                        ],
-                        "type": "Polygon",
-                    }
-                ),
-                srid=4326,
-            ),
-        )
-
-        Department_subdivided.objects.create(
-            code="01",
-            name="Ain",
-            shape=GEOSGeometry(
-                "POLYGON ((-1.1445170773446591 50.14048784607837, -1.1445170773446591 48.46067765220832, 2.180844882808316 48.46067765220832, 2.180844882808316 50.14048784607837, -1.1445170773446591 50.14048784607837))"
-            ),
-        )
-
-        Department_subdivided.objects.create(
-            code="02",
-            name="Aisne",
-            shape=GEOSGeometry(
-                "POLYGON ((4.023367285356358 49.55818275540048, 4.023367285356358 48.001809772072534, 7.459707468976717 48.001809772072534, 7.459707468976717 49.55818275540048, 4.023367285356358 49.55818275540048))"
-            ),
-        )
-
-        # Buildings in Paris
-        Building.objects.create(
-            rnb_id="p_1",
-            point=GEOSGeometry("POINT (2.3151031002108637 48.853855939132494)"),
-        )
-        Building.objects.create(
-            rnb_id="p_2",
-            point=GEOSGeometry("POINT (2.366944834508937 48.87440863357778)"),
-        )
-
-        # Contributions in Paris
-        Contribution.objects.create(rnb_id="p_1", text="", email="lucie@dummy.fr")
-        Contribution.objects.create(rnb_id="p_2", text="", email="lucie@dummy.fr")
-
-        # Buildings in Ain
-        Building.objects.create(rnb_id="1_1", point=GEOSGeometry("POINT (0 49)"))
-        Building.objects.create(rnb_id="1_2", point=GEOSGeometry("POINT (0 49)"))
-        # Buildings in Aisne
-        Building.objects.create(rnb_id="2_1", point=GEOSGeometry("POINT (5 49)"))
-        Building.objects.create(rnb_id="2_2", point=GEOSGeometry("POINT (5 49)"))
-
-        # Contributions in Ain
-        Contribution.objects.create(rnb_id="1_1", text="", email="riri@email.fr")
-        Contribution.objects.create(rnb_id="1_2", text="", email="fifi@email.fr")
-        Contribution.objects.create(rnb_id="1_2", text="", email="loulou@email.fr")
-
-        # Contributions in Aisne
-        Contribution.objects.create(rnb_id="2_1", text="", email="riri@email.fr")
-        Contribution.objects.create(rnb_id="2_2", text="", email="fifi@email.fr")
-
-        # refused contribution
-        Contribution.objects.create(
-            rnb_id="2_1", text="", email="riri@email.fr", status="refused"
-        )
-
-        r = self.client.get("/api/alpha/contributions/ranking/")
-        response = r.json()
-
-        self.assertEqual(r.status_code, 200)
-        self.assertTrue("departement" in response)
-        self.assertTrue("city" in response)
-        self.assertTrue("individual" in response)
-
-        # individual ranking : [[count1, rank1], [count2, rank2], ...]
-        # departement ranking : [[dpt_code1, dpt_name1, dpt_count1], [dpt_code2, dpt_name2, dpt_count2], ...]
-        self.assertEqual(
-            response,
-            {
-                "individual": [[2, 1], [2, 1], [2, 1], [1, 4]],
-                "departement": [
-                    ["01", "Ain", 3],
-                    ["02", "Aisne", 2],
-                    ["75", "Paris", 2],
-                ],
-                "city": [["75056", "Paris", 2]],
-                "global": 7,
-            },
-        )
+    # @freeze_time("2024-08-05")
+    # def test_ranking(self):
+    #     from batid.models import Department_subdivided
+    #
+    #     create_grenoble()
+    #     create_paris()
+    #
+    #     Department_subdivided.objects.create(
+    #         code="75",
+    #         name="Paris",
+    #         shape=GEOSGeometry(
+    #             json.dumps(
+    #                 {
+    #                     "coordinates": [
+    #                         [
+    #                             [2.353306071148694, 48.90085197679912],
+    #                             [2.298936023110457, 48.89580357010155],
+    #                             [2.273133288448662, 48.87419062799353],
+    #                             [2.2602319211170823, 48.84630219945575],
+    #                             [2.313373267504062, 48.82102752865572],
+    #                             [2.372965297558153, 48.81678013291423],
+    #                             [2.4175057323916462, 48.84407854008418],
+    #                             [2.411362224139367, 48.878837188722514],
+    #                             [2.3907814714921187, 48.89964040569237],
+    #                             [2.353306071148694, 48.90085197679912],
+    #                         ]
+    #                     ],
+    #                     "type": "Polygon",
+    #                 }
+    #             ),
+    #             srid=4326,
+    #         ),
+    #     )
+    #
+    #     Department_subdivided.objects.create(
+    #         code="01",
+    #         name="Ain",
+    #         shape=GEOSGeometry(
+    #             "POLYGON ((-1.1445170773446591 50.14048784607837, -1.1445170773446591 48.46067765220832, 2.180844882808316 48.46067765220832, 2.180844882808316 50.14048784607837, -1.1445170773446591 50.14048784607837))"
+    #         ),
+    #     )
+    #
+    #     Department_subdivided.objects.create(
+    #         code="02",
+    #         name="Aisne",
+    #         shape=GEOSGeometry(
+    #             "POLYGON ((4.023367285356358 49.55818275540048, 4.023367285356358 48.001809772072534, 7.459707468976717 48.001809772072534, 7.459707468976717 49.55818275540048, 4.023367285356358 49.55818275540048))"
+    #         ),
+    #     )
+    #
+    #     # Buildings in Paris
+    #     Building.objects.create(
+    #         rnb_id="p_1",
+    #         point=GEOSGeometry("POINT (2.3151031002108637 48.853855939132494)"),
+    #     )
+    #     Building.objects.create(
+    #         rnb_id="p_2",
+    #         point=GEOSGeometry("POINT (2.366944834508937 48.87440863357778)"),
+    #     )
+    #
+    #     # Contributions in Paris
+    #     Contribution.objects.create(rnb_id="p_1", text="", email="lucie@dummy.fr")
+    #     Contribution.objects.create(rnb_id="p_2", text="", email="lucie@dummy.fr")
+    #
+    #     # Buildings in Ain
+    #     Building.objects.create(rnb_id="1_1", point=GEOSGeometry("POINT (0 49)"))
+    #     Building.objects.create(rnb_id="1_2", point=GEOSGeometry("POINT (0 49)"))
+    #     # Buildings in Aisne
+    #     Building.objects.create(rnb_id="2_1", point=GEOSGeometry("POINT (5 49)"))
+    #     Building.objects.create(rnb_id="2_2", point=GEOSGeometry("POINT (5 49)"))
+    #
+    #     # Contributions in Ain
+    #     Contribution.objects.create(rnb_id="1_1", text="", email="riri@email.fr")
+    #     Contribution.objects.create(rnb_id="1_2", text="", email="fifi@email.fr")
+    #     Contribution.objects.create(rnb_id="1_2", text="", email="loulou@email.fr")
+    #
+    #     # Contributions in Aisne
+    #     Contribution.objects.create(rnb_id="2_1", text="", email="riri@email.fr")
+    #     Contribution.objects.create(rnb_id="2_2", text="", email="fifi@email.fr")
+    #
+    #     # refused contribution
+    #     Contribution.objects.create(
+    #         rnb_id="2_1", text="", email="riri@email.fr", status="refused"
+    #     )
+    #
+    #     r = self.client.get("/api/alpha/contributions/ranking/")
+    #     response = r.json()
+    #
+    #     self.assertEqual(r.status_code, 200)
+    #     self.assertTrue("departement" in response)
+    #     self.assertTrue("city" in response)
+    #     self.assertTrue("individual" in response)
+    #
+    #     # individual ranking : [[count1, rank1], [count2, rank2], ...]
+    #     # departement ranking : [[dpt_code1, dpt_name1, dpt_count1], [dpt_code2, dpt_name2, dpt_count2], ...]
+    #     self.assertEqual(
+    #         response,
+    #         {
+    #             "individual": [[2, 1], [2, 1], [2, 1], [1, 4]],
+    #             "departement": [
+    #                 ["01", "Ain", 3],
+    #                 ["02", "Aisne", 2],
+    #                 ["75", "Paris", 2],
+    #             ],
+    #             "city": [["75056", "Paris", 2]],
+    #             "global": 7,
+    #         },
+    #     )
 
     def test_contribution_permissions_list(self):
         # you cannot list contributions

--- a/app/api_alpha/validators.py
+++ b/app/api_alpha/validators.py
@@ -11,8 +11,15 @@ def ads_validate_rnbid(rnb_id):
 
 def bdg_is_active(rnb_id: str):
 
-    if Building.objects.filter(rnb_id=rnb_id, is_active=False).exists():
+    bdg = Building.objects.filter(rnb_id=rnb_id).first()
+
+    if bdg is None:
+        raise serializers.ValidationError(f'Building "{rnb_id}" does not exist.')
+
+    if not bdg.is_active:
         raise serializers.ValidationError(f'Building "{rnb_id}" is not active.')
+
+
 
 
 class BdgInADSValidator:

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -1165,35 +1165,11 @@ class ContributionsViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
 
         if serializer.is_valid():
             serializer.save()
-            if request.query_params.get("ranking") == "true" and request.data.get(
-                "email"
-            ):
-                count, rank = get_contributor_count_and_rank(request.data.get("email"))
-                response = dict(serializer.data)
-                response["contributor_count"] = count
-                response["contributor_rank"] = rank
-                return Response(response, status=201)
-            else:
-                return Response(serializer.data, status=201)
+            return Response(serializer.data, status=201)
         else:
             return Response(serializer.errors, status=400)
 
-    @action(detail=False, methods=["get"])
-    def ranking(self, request, *args, **kwargs):
-        individual = individual_ranking()
-        departement = departement_ranking()
-        city = city_ranking()
-        all_contributions = Contribution.objects.filter(
-            status__in=["fixed", "pending"],
-            created_at__lt=timezone.make_aware(datetime(2024, 9, 4)),
-        ).count()
-        data = {
-            "individual": individual,
-            "city": city,
-            "departement": departement,
-            "global": all_contributions,
-        }
-        return Response(data, status=200)
+
 
 
 def get_contributor_count_and_rank(email):


### PR DESCRIPTION
La [PR471](https://github.com/fab-geocommuns/RNB-coeur/pull/471) combinée au grand nettoyage des doublons/légers a ralenti le endpoint de réception des signalements (environ 9 secondes pour que le serveur réponde).

En bref, à la réception d'une contribution, on vérifie que l'identifiant concerné est actif. Le problème est que la requête telle qu'elle était écrite déclenchait un IndexScan sur le critère `is_active=False` puis passait en revue les 5M de lignes pour trouver le bon identifiant RNB.

J'ai changé la vérification pour que l'on récupère d'abord le bâtiment via rnb_id puis qu'on vérifie son `is_active`.

La version plus propre aurait probablement été de faire cette vérification en une opération. Il aurait fallu créer un index combiné `rnb_id` et `is_active` mais j'ai estimé que c'était trop lourd au vu de notre usage de cette vérification.

J'en ai profité pour faire un peu de nettoyage du jeu de l'été.