### PR TITLE
Utilitaire de mise en cache de stats

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -208,6 +208,11 @@ CELERY_BEAT_SCHEDULE = {
             minute=0, hour=0, day_of_month=15, month_of_year="1,4,7,10"
         ),
     },
+    "fetch_stats": {
+        "tasks": "batid.tasks.renew_stats",
+        # everyday at 3am
+        "schedule": crontab(hour=3, minute=0),
+    }
 }
 
 # URL of the project

--- a/app/batid/management/commands/fetch_stats.py
+++ b/app/batid/management/commands/fetch_stats.py
@@ -1,0 +1,15 @@
+from django.core.management.base import BaseCommand
+
+from app.celery import app
+from batid.services.stats import fetch_stats, get_path
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+
+        print('Fetching stats...')
+        fetch_stats()
+        print('Done.')
+        print(f"Stats have been saved in {get_path()}")
+

--- a/app/batid/services/source.py
+++ b/app/batid/services/source.py
@@ -52,6 +52,7 @@ class Source:
                 "filename": "commune_insee.csv",
             },
             "export": {"filename": "export-{{city}}-{{date}}.geojson"},
+            "cached_stats": {"filename": "cached_stats.json"},
         }
 
     def set_param(self, p_key, p_val):

--- a/app/batid/services/stats.py
+++ b/app/batid/services/stats.py
@@ -1,0 +1,48 @@
+import json
+import os.path
+
+from batid.services.source import Source
+
+
+def all_stats():
+
+    src = _get_source()
+
+    # Check if the file exists, if not create it
+    if not os.path.exists(src.path):
+        json.dump({}, open(src.path, "w"))
+
+    # Read and return
+    with open(src.path, "r") as f:
+        return json.load(f)
+
+def set_stat(key:str, value):
+
+    if not isinstance(key, str):
+        raise ValueError("Key must be a string")
+
+
+    stats = all_stats()
+
+    stats[key] = value
+
+    src = _get_source()
+
+    with open(src.path, "w") as f:
+        json.dump(stats, f)
+
+    return
+
+def _get_source():
+    return Source("cached_stats")
+
+def get_path():
+    return _get_source().path
+
+def clear_stats():
+    src = _get_source()
+
+    if os.path.exists(src.path):
+        os.remove(src.path)
+
+    return

--- a/app/batid/services/stats.py
+++ b/app/batid/services/stats.py
@@ -1,8 +1,11 @@
 import json
 import os.path
 
+from batid.models import Building
 from batid.services.source import Source
 
+
+ACTIVE_BUILDING_COUNT = "active_building_count"
 
 def all_stats():
 
@@ -15,6 +18,15 @@ def all_stats():
     # Read and return
     with open(src.path, "r") as f:
         return json.load(f)
+
+def get_stat(key:str):
+
+    if not isinstance(key, str):
+        raise ValueError("Key must be a string")
+
+    stats = all_stats()
+
+    return stats.get(key, None)
 
 def set_stat(key:str, value):
 
@@ -46,3 +58,10 @@ def clear_stats():
         os.remove(src.path)
 
     return
+
+
+def fetch_stats():
+
+    # Active building count
+    count = Building.objects.filter(is_active=True).count()
+    set_stat(ACTIVE_BUILDING_COUNT, count)

--- a/app/batid/tasks.py
+++ b/app/batid/tasks.py
@@ -80,6 +80,7 @@ def convert_bdtopo(src_params, bulk_launch_uuid=None):
     return "done"
 
 
+
 @notify_if_error
 @shared_task(autoretry_for=(Exception,), retry_kwargs={"max_retries": 3})
 def queue_full_bdtopo_import(
@@ -205,4 +206,20 @@ def list_light_buildings_france(start_dpt=None, end_dpt=None):
 @shared_task(autoretry_for=(Exception,), retry_kwargs={"max_retries": 0})
 def remove_light_buildings(folder_name, username, fix_id):
     remove_light_buildings_job(folder_name, username, fix_id)
+    return "done"
+
+
+@notify_if_error
+@shared_task(autoretry_for=(Exception,), retry_kwargs={"max_retries": 3})
+def renew_stats():
+
+    """
+    This task is in charge of calculating some stats displayed on https://rnb.beta.gouv.fr/stats
+    It is too expensive to calculate them on the fly, so we calculate them once a day and store them in a file
+    :return:
+    """
+
+    from batid.services.stats import fetch_stats
+
+    fetch_stats()
     return "done"

--- a/app/batid/tasks.py
+++ b/app/batid/tasks.py
@@ -209,7 +209,7 @@ def remove_light_buildings(folder_name, username, fix_id):
     return "done"
 
 
-@notify_if_error
+
 @shared_task(autoretry_for=(Exception,), retry_kwargs={"max_retries": 3})
 def renew_stats():
 

--- a/app/batid/tests/test_stats.py
+++ b/app/batid/tests/test_stats.py
@@ -1,0 +1,69 @@
+import os
+
+from django.test import TestCase
+
+from batid.services.stats import get_path, all_stats, set_stat, clear_stats
+
+
+class TestStats(TestCase):
+
+    def test_create_if_needed(self):
+
+        # Remove the file
+        clear_stats()
+
+        # Get the file path and check it does not exist
+        src_path = get_path()
+        self.assertFalse(os.path.exists(src_path))
+
+        # Try to read it
+        stats = all_stats()
+
+        # Check the file is created and filled with an empty dict
+        self.assertTrue(os.path.exists(src_path))
+        self.assertEqual(stats, {})
+
+
+    def test_set_one_key(self):
+
+        # Start from empty slate
+        clear_stats()
+
+        # Set one value
+        set_stat("life_meaning", 42)
+
+        # Read it
+        stats = all_stats()
+        self.assertDictEqual(stats, {"life_meaning": 42})
+
+
+    def test_update_one_key(self):
+
+        # Start from empty slate
+        clear_stats()
+
+        # Set one value
+        set_stat("life_meaning", 42)
+        # Check the value
+        stats = all_stats()
+        self.assertDictEqual(stats, {"life_meaning": 42})
+
+        # Update the value
+        set_stat("life_meaning", 43)
+        # Check again the value
+        stats = all_stats()
+        self.assertDictEqual(stats, {"life_meaning": 43})
+
+
+    def test_key_must_be_str(self):
+
+        # Start from empty slate
+        clear_stats()
+
+        # Try to set a non-string key
+        with self.assertRaises(ValueError):
+            set_stat(42, 42)
+
+        # Check the file is still empty
+        stats = all_stats()
+        self.assertEqual(stats, {})


### PR DESCRIPTION
Le [compte de bâtiments sur le site](https://rnb.beta.gouv.fr/stats) n'est plus à jour du fait de la méthode de calcul et du nombre important d'identifiants désactivés.

Il semble nécessaire de mettre en cache cette valeur pour éviter des calculs trop lourds. Cette PR ajoute quelques utilitaires pour faire cela : 

- les fonctions disponibles dans `batid/services/stats.py` permettent de lire et d'écrire ces stats
- la commande `fetch_stats` permet de déclencher un calcul des stats manuellement
- la tâche `batid.tasks.renew_stats` qui sera appelée tous les jours à 3h (la nuit)

Une fois cette PR mergée, il restera à modifier le endpoint `/api_alpha/stats/` pour brancher la donnée `building_counts` sur ce fichier de cache.