### PR TITLE
Lire bdg_count depuis fichier de cache

### DIFF
--- a/app/api_alpha/tests/test_views.py
+++ b/app/api_alpha/tests/test_views.py
@@ -11,14 +11,25 @@ from rest_framework_tracking.models import APIRequestLog
 
 from batid.models import Building
 from batid.models import Contribution
+from batid.services.stats import compute_stats
 
 
 class StatsTest(APITestCase):
+    @mock.patch("batid.services.source.Source.default_ref")
     @mock.patch("api_alpha.views.requests.get")
-    def test_stats(self, get_mock):
-        # create 2 buldings
-        Building.objects.create(rnb_id="1")
-        Building.objects.create(rnb_id="2")
+    def test_stats(self, get_mock, default_src_ref_mock):
+
+        # Mock the path to the cached stats file
+        default_src_ref_mock.return_value = {
+            "cached_stats": {"filename": "test_cached_stats.json"}
+        }
+
+        # create buildings for building count
+        Building.objects.create(rnb_id="1", is_active=True)
+        Building.objects.create(rnb_id="2", is_active=True)
+        Building.objects.create(rnb_id="3", is_active=False)
+        # trigger the stats computation for building count
+        compute_stats()
 
         # create one contribution
         Contribution.objects.create()
@@ -27,18 +38,17 @@ class StatsTest(APITestCase):
         APIRequestLog.objects.create(requested_at="2023-01-01T00:00:00Z")
         APIRequestLog.objects.create(requested_at="2024-01-02T00:00:00Z")
 
-        # # count the number of buildings to update the estimate in the DB
-        Building.objects.count()
-
+        # mock the data.gouv API
         get_mock.return_value.status_code = 200
         get_mock.return_value.json.return_value = {"total": 12}
 
-        r = self.client.get("/api/alpha/stats")
 
+        r = self.client.get("/api/alpha/stats")
         self.assertEqual(r.status_code, 200)
         results = r.json()
-        # assert building_counts is in a range, because it's an estimate
-        self.assertGreaterEqual(results["building_counts"], -2)
+
+
+        self.assertEqual(results["building_counts"], 2)
         self.assertLess(results["building_counts"], 4)
         self.assertEqual(results["api_calls_since_2024_count"], 1)
         self.assertEqual(results["contributions_count"], 1)

--- a/app/api_alpha/tests/test_views.py
+++ b/app/api_alpha/tests/test_views.py
@@ -42,11 +42,9 @@ class StatsTest(APITestCase):
         get_mock.return_value.status_code = 200
         get_mock.return_value.json.return_value = {"total": 12}
 
-
         r = self.client.get("/api/alpha/stats")
         self.assertEqual(r.status_code, 200)
         results = r.json()
-
 
         self.assertEqual(results["building_counts"], 2)
         self.assertLess(results["building_counts"], 4)

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -1,7 +1,7 @@
 import json
 import os
 from base64 import b64encode
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import requests
 from django.conf import settings
@@ -56,8 +56,12 @@ from batid.models import Contribution
 from batid.models import Organization
 from batid.services.closest_bdg import get_closest_from_point
 from batid.services.guess_bdg import BuildingGuess
+from batid.services.mattermost import notify_tech
 from batid.services.rnb_id import clean_rnb_id
 from batid.services.search_ads import ADSSearch
+from batid.services.stats import get_stat as get_cached_stat
+from batid.services.stats import ACTIVE_BUILDING_COUNT
+
 from batid.services.vector_tiles import ads_tiles_sql
 from batid.services.vector_tiles import bdgs_tiles_sql
 from batid.services.vector_tiles import url_params_to_tile
@@ -1008,8 +1012,16 @@ def get_stats(request):
     contributions_count = Contribution.objects.count()
     data_gouv_publication_count = get_data_gouv_publication_count()
 
+    # Get the cached value of the building count
+    bdg_count = get_cached_stat(ACTIVE_BUILDING_COUNT)
+    # check the "computed_at" date is not too old
+    if bdg_count["computed_at"] < datetime.now() - timedelta(days=2):
+        # if it is, we warn the tech channel
+        notify_tech(f"Le calcul du nombre de bâtiments disponible dans le cache est trop vieux. Il date de {bdg_count["computed_at"].isoformat()}")
+
+
     data = {
-        "building_counts": building_counts,
+        "building_counts": bdg_count["value"],
         "api_calls_since_2024_count": api_calls_since_2024_count,
         "contributions_count": contributions_count,
         "data_gouv_publication_count": data_gouv_publication_count,

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -1,7 +1,8 @@
 import json
 import os
 from base64 import b64encode
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 
 import requests
 from django.conf import settings
@@ -59,9 +60,8 @@ from batid.services.guess_bdg import BuildingGuess
 from batid.services.mattermost import notify_tech
 from batid.services.rnb_id import clean_rnb_id
 from batid.services.search_ads import ADSSearch
-from batid.services.stats import get_stat as get_cached_stat
 from batid.services.stats import ACTIVE_BUILDING_COUNT
-
+from batid.services.stats import get_stat as get_cached_stat
 from batid.services.vector_tiles import ads_tiles_sql
 from batid.services.vector_tiles import bdgs_tiles_sql
 from batid.services.vector_tiles import url_params_to_tile

--- a/app/batid/services/stats.py
+++ b/app/batid/services/stats.py
@@ -75,9 +75,7 @@ def clear_stats():
 def _convert_str_to_dates(data):
     for key in data:
         if "computed_at" in data[key]:
-            data[key]["computed_at"] = datetime.fromisoformat(
-                data[key]["computed_at"]
-            )
+            data[key]["computed_at"] = datetime.fromisoformat(data[key]["computed_at"])
 
     return data
 

--- a/app/batid/services/stats.py
+++ b/app/batid/services/stats.py
@@ -44,7 +44,7 @@ def set_stat(key: str, value):
 
     stats = all_stats()
 
-    stats[key] = {"value": value, "calculated_at": datetime.now()}
+    stats[key] = {"value": value, "computed_at": datetime.now()}
 
     src = _get_source()
 
@@ -74,9 +74,9 @@ def clear_stats():
 
 def _convert_str_to_dates(data):
     for key in data:
-        if "calculated_at" in data[key]:
-            data[key]["calculated_at"] = datetime.fromisoformat(
-                data[key]["calculated_at"]
+        if "computed_at" in data[key]:
+            data[key]["computed_at"] = datetime.fromisoformat(
+                data[key]["computed_at"]
             )
 
     return data
@@ -84,8 +84,8 @@ def _convert_str_to_dates(data):
 
 def _convert_dates_to_str(data):
     for key in data:
-        if "calculated_at" in data[key]:
-            data[key]["calculated_at"] = data[key]["calculated_at"].isoformat()
+        if "computed_at" in data[key]:
+            data[key]["computed_at"] = data[key]["computed_at"].isoformat()
 
     return data
 

--- a/app/batid/tests/test_stats.py
+++ b/app/batid/tests/test_stats.py
@@ -64,7 +64,7 @@ class TestStatsHelper(AbstractStatTests):
         # Read it
         stats = all_stats()
         self.assertEqual(stats["life_meaning"]["value"], 42)
-        self.assertIsInstance(stats["life_meaning"]["calculated_at"], datetime)
+        self.assertIsInstance(stats["life_meaning"]["computed_at"], datetime)
 
     def test_update_one_key(self):
 
@@ -76,17 +76,17 @@ class TestStatsHelper(AbstractStatTests):
         # Check the value
         stats = all_stats()
         self.assertEqual(stats["life_meaning"]["value"], 42)
-        first_calculated_at = stats["life_meaning"]["calculated_at"]
+        first_computed_at = stats["life_meaning"]["computed_at"]
 
         # Update the value
         set_stat("life_meaning", 43)
         # Check again the value
         stats = all_stats()
         self.assertEqual(stats["life_meaning"]["value"], 43)
-        second_calculated_at = stats["life_meaning"]["calculated_at"]
+        second_computed_at = stats["life_meaning"]["computed_at"]
 
-        # Verify the calculated_at has been updated
-        self.assertGreater(second_calculated_at, first_calculated_at)
+        # Verify the computed_at has been updated
+        self.assertGreater(second_computed_at, first_computed_at)
 
     def test_get_stat(self):
 
@@ -99,7 +99,7 @@ class TestStatsHelper(AbstractStatTests):
         # Read it
         stat = get_stat("life_meaning")
         self.assertEqual(stat["value"], 42)
-        self.assertIsInstance(stat["calculated_at"], datetime)
+        self.assertIsInstance(stat["computed_at"], datetime)
 
     def test_key_must_be_str(self):
 


### PR DESCRIPTION
J'ai modifié la façon dont est obtenu le nombre de bâtiments actifs depuis `/api_alpha/stats/`.
On passe maitenant par le chiffre mis en cache (cf [PR485](https://github.com/fab-geocommuns/RNB-coeur/pull/485))