### PR TITLE
Réparation de l'inspecteur

### DIFF
--- a/app/batid/services/candidate.py
+++ b/app/batid/services/candidate.py
@@ -166,12 +166,15 @@ class Inspector:
 
         if has_changed:
             bdg.save()
-
-        # Finally, we update the candidate
-        self.candidate.inspection_details = {
-            "decision": "update",
-            "rnb_id": bdg.rnb_id,
-        }
+            self.candidate.inspection_details = {
+                "decision": "update",
+                "rnb_id": bdg.rnb_id,
+            }
+        else:
+            self.candidate.inspection_details = {
+                "decision": "refusal",
+                "reason": "nothing_to_update",
+            }
         self.candidate.save()
 
     def calc_bdg_update(self, bdg: Building):
@@ -215,7 +218,7 @@ class Inspector:
 
         bdg_addresses = sort_handle_null(bdg.addresses_id)
         candidate_addresses = sort_handle_null(self.candidate.address_keys)
-        if bdg_addresses != candidate_addresses:
+        if bdg_addresses != candidate_addresses and candidate_addresses:
             has_changed = True
             # concatenate the two lists and remove duplicates
             bdg.addresses_id = list(set(bdg_addresses + candidate_addresses))


### PR DESCRIPTION
2 bugs dans l'inspecteur :
- un candidat qui n'a pas d'adresse et qui matche un building qui a déjà des adresses donnait lieu à un update.
- un candidat qui ne donne après check pas lieu à une mise à jour de building avait quand même une décision de "update" enregistrée dans les inspection_details.

Je rajoute un test qui vérifie ces deux points.