### PR TITLE
Ajout des COM manquantes

### DIFF
--- a/app/batid/management/commands/dpt_count.py
+++ b/app/batid/management/commands/dpt_count.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand
 
 from batid.models import Building
 from batid.models import Department
-from batid.services.administrative_areas import dpt_codes, dpts_list
+from batid.services.administrative_areas import dpts_list
 
 
 class Command(BaseCommand):

--- a/app/batid/management/commands/dpt_count.py
+++ b/app/batid/management/commands/dpt_count.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand
 
 from batid.models import Building
 from batid.models import Department
-from batid.services.administrative_areas import dpt_codes
+from batid.services.administrative_areas import dpt_codes, dpts_list
 
 
 class Command(BaseCommand):
@@ -10,7 +10,7 @@ class Command(BaseCommand):
         parser.add_argument("--dpt", type=str, default="all")
 
     def handle(self, *args, **options):
-        codes = dpt_codes() if options["dpt"] == "all" else options["dpt"].split(",")
+        codes = dpts_list() if options["dpt"] == "all" else options["dpt"].split(",")
 
         for code in codes:
             dpt = Department.objects.get(code=code)

--- a/app/batid/management/commands/import_dpt.py
+++ b/app/batid/management/commands/import_dpt.py
@@ -1,0 +1,20 @@
+from django.core.management.base import BaseCommand
+
+from batid.services.administrative_areas import validate_dpt_code
+from batid.services.imports.import_dpt import import_one_department
+
+
+class Command(BaseCommand):
+    help = "Import shape and name of a department"
+
+    def add_arguments(self, parser):
+        parser.add_argument("dpt", type=str)
+
+    def handle(self, *args, **options):
+
+        print(f"Importing department {options['dpt']}")
+
+        if validate_dpt_code(options["dpt"]):
+            import_one_department(options["dpt"])
+
+        print("Done")

--- a/app/batid/services/administrative_areas.py
+++ b/app/batid/services/administrative_areas.py
@@ -13,11 +13,6 @@ def fetch_dpt_cities_geojson(dpt: str) -> dict:
     return requests.get(url).json()
 
 
-def fetch_departments_refs() -> dict:
-    url = "https://geo.api.gouv.fr/departements"
-    return requests.get(url).json()
-
-
 def _dpt_names() -> dict:
     return {
         "01": "Ain",

--- a/app/batid/services/administrative_areas.py
+++ b/app/batid/services/administrative_areas.py
@@ -18,16 +18,6 @@ def fetch_departments_refs() -> dict:
     return requests.get(url).json()
 
 
-def dpt_codes() -> set:
-    # this function is used in few places and should be replaced with dpts_list()
-    metro = {str(i).zfill(2) for i in range(1, 96)}
-    metro.add("2A")
-    metro.add("2B")
-    metro.remove("20")
-    outre_mer = set(["971", "972", "973", "974", "976"])
-    return metro.union(outre_mer)
-
-
 def dpt_list_metropole():
     return [
         "01",

--- a/app/batid/services/administrative_areas.py
+++ b/app/batid/services/administrative_areas.py
@@ -255,3 +255,7 @@ def dpts_list(start: Optional[str] = None, end: Optional[str] = None):
 
 def dpt_name(code: str) -> str:
     return _dpt_names()[code]
+
+
+def validate_dpt_code(code: str):
+    return code in dpts_list()

--- a/app/batid/services/administrative_areas.py
+++ b/app/batid/services/administrative_areas.py
@@ -120,8 +120,11 @@ def dpt_list_metropole():
 
 
 def dpt_list_overseas():
-    return ["971", "972", "973", "974", "975", "976", "977", "978"]
+    return ["971", "972", "973", "974", "976"]
 
+# COM = Collectivité d'outre-mer
+def com_list():
+    return ["975", "977", "978", "986", "987"]
 
 def dpts_list(start: Optional[str] = None, end: Optional[str] = None):
     """
@@ -130,9 +133,28 @@ def dpts_list(start: Optional[str] = None, end: Optional[str] = None):
     :return: list of departments in France
     """
 
-    all = dpt_list_metropole() + dpt_list_overseas()
+    all = dpt_list_metropole() + dpt_list_overseas() + com_list()
 
     start_idx = all.index(start) if start else 0
     end_idx = all.index(end) + 1 if end else len(all)
 
     return all[start_idx:end_idx]
+
+def get_com_name(code: str) -> str:
+    # We hard code this list, since those names are not avaialbe via fetch_departments_refs()
+    # Those territories are not in https://geo.api.gouv.fr/departements (they are not departments)
+
+    if code not in com_list():
+        raise ValueError(f"{code} is not a COM code")
+
+    names = {
+        "975": "Saint-Pierre-et-Miquelon",
+        "977": "Saint-Barthélemy",
+        "978": "Saint-Martin",
+        "986": "Wallis-et-Futuna",
+        "987": "Polynésie française",
+    }
+
+    return names[code]
+
+

--- a/app/batid/services/administrative_areas.py
+++ b/app/batid/services/administrative_areas.py
@@ -18,6 +18,121 @@ def fetch_departments_refs() -> dict:
     return requests.get(url).json()
 
 
+def _dpt_names() -> dict:
+    return {
+        "01": "Ain",
+        "02": "Aisne",
+        "03": "Allier",
+        "04": "Alpes-de-Haute-Provence",
+        "05": "Hautes-Alpes",
+        "06": "Alpes-Maritimes",
+        "07": "Ardèche",
+        "08": "Ardennes",
+        "09": "Ariège",
+        "10": "Aube",
+        "11": "Aude",
+        "12": "Aveyron",
+        "13": "Bouches-du-Rhône",
+        "14": "Calvados",
+        "15": "Cantal",
+        "16": "Charente",
+        "17": "Charente-Maritime",
+        "18": "Cher",
+        "19": "Corrèze",
+        "21": "Côte-d'Or",
+        "22": "Côtes-d'Armor",
+        "23": "Creuse",
+        "24": "Dordogne",
+        "25": "Doubs",
+        "26": "Drôme",
+        "27": "Eure",
+        "28": "Eure-et-Loir",
+        "29": "Finistère",
+        "2A": "Corse-du-Sud",
+        "2B": "Haute-Corse",
+        "30": "Gard",
+        "31": "Haute-Garonne",
+        "32": "Gers",
+        "33": "Gironde",
+        "34": "Hérault",
+        "35": "Ille-et-Vilaine",
+        "36": "Indre",
+        "37": "Indre-et-Loire",
+        "38": "Isère",
+        "39": "Jura",
+        "40": "Landes",
+        "41": "Loir-et-Cher",
+        "42": "Loire",
+        "43": "Haute-Loire",
+        "44": "Loire-Atlantique",
+        "45": "Loiret",
+        "46": "Lot",
+        "47": "Lot-et-Garonne",
+        "48": "Lozère",
+        "49": "Maine-et-Loire",
+        "50": "Manche",
+        "51": "Marne",
+        "52": "Haute-Marne",
+        "53": "Mayenne",
+        "54": "Meurthe-et-Moselle",
+        "55": "Meuse",
+        "56": "Morbihan",
+        "57": "Moselle",
+        "58": "Nièvre",
+        "59": "Nord",
+        "60": "Oise",
+        "61": "Orne",
+        "62": "Pas-de-Calais",
+        "63": "Puy-de-Dôme",
+        "64": "Pyrénées-Atlantiques",
+        "65": "Hautes-Pyrénées",
+        "66": "Pyrénées-Orientales",
+        "67": "Bas-Rhin",
+        "68": "Haut-Rhin",
+        "69": "Rhône",
+        "70": "Haute-Saône",
+        "71": "Saône-et-Loire",
+        "72": "Sarthe",
+        "73": "Savoie",
+        "74": "Haute-Savoie",
+        "75": "Paris",
+        "76": "Seine-Maritime",
+        "77": "Seine-et-Marne",
+        "78": "Yvelines",
+        "79": "Deux-Sèvres",
+        "80": "Somme",
+        "81": "Tarn",
+        "82": "Tarn-et-Garonne",
+        "83": "Var",
+        "84": "Vaucluse",
+        "85": "Vendée",
+        "86": "Vienne",
+        "87": "Haute-Vienne",
+        "88": "Vosges",
+        "89": "Yonne",
+        "90": "Territoire de Belfort",
+        "91": "Essonne",
+        "92": "Hauts-de-Seine",
+        "93": "Seine-Saint-Denis",
+        "94": "Val-de-Marne",
+        "95": "Val-d'Oise",
+        # ####
+        # Départements our Régions d'outre-mer
+        "971": "Guadeloupe",
+        "972": "Martinique",
+        "973": "Guyane",
+        "974": "La Réunion",
+        "976": "Mayotte",
+        # ####
+        # Collectivités d'outre-mer
+        "975": "Saint-Pierre-et-Miquelon",
+        "977": "Saint-Barthélemy",
+        "978": "Saint-Martin",
+        "986": "Wallis-et-Futuna",
+        "987": "Polynésie française",
+    }
+
+
 def dpt_list_metropole():
     return [
         "01",
@@ -122,9 +237,11 @@ def dpt_list_metropole():
 def dpt_list_overseas():
     return ["971", "972", "973", "974", "976"]
 
+
 # COM = Collectivité d'outre-mer
 def com_list():
     return ["975", "977", "978", "986", "987"]
+
 
 def dpts_list(start: Optional[str] = None, end: Optional[str] = None):
     """
@@ -140,21 +257,6 @@ def dpts_list(start: Optional[str] = None, end: Optional[str] = None):
 
     return all[start_idx:end_idx]
 
-def get_com_name(code: str) -> str:
-    # We hard code this list, since those names are not avaialbe via fetch_departments_refs()
-    # Those territories are not in https://geo.api.gouv.fr/departements (they are not departments)
 
-    if code not in com_list():
-        raise ValueError(f"{code} is not a COM code")
-
-    names = {
-        "975": "Saint-Pierre-et-Miquelon",
-        "977": "Saint-Barthélemy",
-        "978": "Saint-Martin",
-        "986": "Wallis-et-Futuna",
-        "987": "Polynésie française",
-    }
-
-    return names[code]
-
-
+def dpt_name(code: str) -> str:
+    return _dpt_names()[code]

--- a/app/batid/services/imports/import_dpt.py
+++ b/app/batid/services/imports/import_dpt.py
@@ -5,15 +5,18 @@ from django.contrib.gis.geos import MultiPolygon
 from django.db import connection
 
 from batid.models import Department, Department_subdivided
-from batid.services.administrative_areas import fetch_departments_refs
+
 from batid.services.administrative_areas import fetch_dpt_cities_geojson
 
 
 def import_etalab_dpts() -> None:
-    dpts = fetch_departments_refs()
 
     for dpt in dpts:
         cities = fetch_dpt_cities_geojson(dpt["code"])
+
+        if not cities["features"]:
+            print(f"No cities found for {dpt['code']}")
+            continue
 
         polys = []
 
@@ -51,7 +54,3 @@ def import_etalab_dpts() -> None:
 
 def import_one_department(code: str):
     pass
-
-
-
-

--- a/app/batid/services/imports/import_dpt.py
+++ b/app/batid/services/imports/import_dpt.py
@@ -4,14 +4,12 @@ from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.geos import MultiPolygon
 from django.db import connection
 
-from batid.models import Department, Department_subdivided
-
-from batid.services.administrative_areas import (
-    fetch_dpt_cities_geojson,
-    dpts_list,
-    validate_dpt_code,
-    dpt_name,
-)
+from batid.models import Department
+from batid.models import Department_subdivided
+from batid.services.administrative_areas import dpt_name
+from batid.services.administrative_areas import dpts_list
+from batid.services.administrative_areas import fetch_dpt_cities_geojson
+from batid.services.administrative_areas import validate_dpt_code
 
 
 def import_etalab_dpts() -> None:

--- a/app/batid/services/imports/import_dpt.py
+++ b/app/batid/services/imports/import_dpt.py
@@ -6,51 +6,66 @@ from django.db import connection
 
 from batid.models import Department, Department_subdivided
 
-from batid.services.administrative_areas import fetch_dpt_cities_geojson
+from batid.services.administrative_areas import (
+    fetch_dpt_cities_geojson,
+    dpts_list,
+    validate_dpt_code,
+    dpt_name,
+)
 
 
 def import_etalab_dpts() -> None:
 
+    dpts = dpts_list()
+
     for dpt in dpts:
-        cities = fetch_dpt_cities_geojson(dpt["code"])
-
-        if not cities["features"]:
-            print(f"No cities found for {dpt['code']}")
-            continue
-
-        polys = []
-
-        for city in cities["features"]:
-            if city["geometry"]["type"] == "Polygon":
-                polys.append(city["geometry"])
-            elif city["geometry"]["type"] == "MultiPolygon":
-                for poly in city["geometry"]["coordinates"]:
-                    polys.append({"type": "Polygon", "coordinates": poly})
-
-        geoms = [GEOSGeometry(json.dumps(p), srid=4326) for p in polys]
-
-        mp = MultiPolygon(geoms, srid=4326)
-        try:
-            dpt_model = Department.objects.get(code=dpt["code"])
-        except Department.DoesNotExist:
-            dpt_model = Department(code=dpt["code"])
-
-        dpt_model.name = dpt["nom"]
-        dpt_model.shape = mp
-        dpt_model.save()
-
-        # Also build the sub-divided version
-        Department_subdivided.objects.filter(code=dpt["code"]).delete()
-
-        with connection.cursor() as cursor:
-            cursor.execute(
-                """
-                INSERT INTO batid_department_subdivided (code, name, shape)
-                SELECT code, name, ST_SubDivide(shape) as shape
-                FROM batid_department;
-                """
-            )
+        import_one_department(dpt)
 
 
 def import_one_department(code: str):
-    pass
+
+    if not validate_dpt_code(code):
+        raise ValueError(f"Invalid department code: {code}")
+
+    # First, we get all the cities for this department
+    # Those cities have the polygons we want to import
+    cities = fetch_dpt_cities_geojson(code)
+
+    if not cities["features"]:
+        print(f"No cities found for {code}")
+        return
+
+    polys = []
+
+    for city in cities["features"]:
+        if city["geometry"]["type"] == "Polygon":
+            polys.append(city["geometry"])
+        elif city["geometry"]["type"] == "MultiPolygon":
+            for poly in city["geometry"]["coordinates"]:
+                polys.append({"type": "Polygon", "coordinates": poly})
+
+    geoms = [GEOSGeometry(json.dumps(p), srid=4326) for p in polys]
+    mp = MultiPolygon(geoms, srid=4326)
+
+    # Then we upsert the department
+    try:
+        dpt_model = Department.objects.get(code=code)
+    except Department.DoesNotExist:
+        dpt_model = Department(code=code)
+
+    dpt_model.name = dpt_name(code)
+    dpt_model.shape = mp
+    dpt_model.save()
+
+    # Finally, we build the sub-divided version
+    # It is used for faster queries (eg: in data.gouv.fr dataset export)
+    Department_subdivided.objects.filter(code=code).delete()
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            INSERT INTO {Department_subdivided._meta.db_table} (code, name, shape)
+            SELECT code, name, ST_SubDivide(shape) as shape
+            FROM {Department._meta.db_table};
+            """
+        )

--- a/app/batid/tests/test_administrativeareas.py
+++ b/app/batid/tests/test_administrativeareas.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+
+from batid.services.administrative_areas import (
+    dpt_list_metropole,
+    dpt_list_overseas,
+    com_list,
+    dpts_list,
+    dpt_name,
+)
+
+
+class AdminAreas(TestCase):
+
+    def test(self):
+
+        metropole_list = dpt_list_metropole()
+        self.assertEqual(len(metropole_list), 96)
+
+        drom_list = dpt_list_overseas()
+        self.assertEqual(len(drom_list), 5)
+
+        com_overseas_list = com_list()
+        self.assertEqual(len(com_overseas_list), 5)
+
+        all = dpts_list()
+        self.assertEqual(len(all), 106)
+
+        # Test everybody has a name
+        for code in all:
+            try:
+                dpt_name(code)
+            except KeyError:
+                self.fail(f"Missing name for {code}")

--- a/app/batid/tests/test_administrativeareas.py
+++ b/app/batid/tests/test_administrativeareas.py
@@ -1,16 +1,13 @@
 from django.test import TestCase
 
-from batid.services.administrative_areas import (
-    dpt_list_metropole,
-    dpt_list_overseas,
-    com_list,
-    dpts_list,
-    dpt_name,
-)
+from batid.services.administrative_areas import com_list
+from batid.services.administrative_areas import dpt_list_metropole
+from batid.services.administrative_areas import dpt_list_overseas
+from batid.services.administrative_areas import dpt_name
+from batid.services.administrative_areas import dpts_list
 
 
 class AdminAreas(TestCase):
-
     def test(self):
 
         metropole_list = dpt_list_metropole()


### PR DESCRIPTION
Suite à une remarque d'un utilisateur de notre export data gouv, j'ai constaté que certains COM étaient absentes (975, 977, 978) de notre liste de départements (ce ne sont pas des départements à proprement parler mais on les qualifie ainsi par facilité).

J'ai nettoyé quelques fonctions liées aux limites administratives.

Une fois la PR mergée, il faudra procéder manuellement à l'import (commande `import_dpt`) des trois COM manquantes en prod ainsi que des villes (commande `import_cities_dpt`).