### PR TITLE
Suppression d'un problème de N+1 queries

### DIFF
--- a/app/api_alpha/tests/test_buildings.py
+++ b/app/api_alpha/tests/test_buildings.py
@@ -1522,6 +1522,19 @@ class BuildingsWithPlots(APITestCase):
         data = r.json()
         self.assertDictEqual(data, expected_wo_plots)
 
+    def test_no_n_plus_1_query(self):
+        Address.objects.create(id="add_1")
+        Building.objects.create(rnb_id="A", addresses_id=["add_1"], point="POINT(0 0)")
+
+        Address.objects.create(id="add_2")
+        Building.objects.create(rnb_id="B", addresses_id=["add_2"], point="POINT(0 0)")
+
+        def list_buildings():
+            self.client.get("/api/alpha/buildings/")
+
+        # 1 for the query, 1 to log the call in rest_framework_tracking_apirequestlog
+        self.assertNumQueries(3, list_buildings)
+
     def test_single_bdg(self):
 
         expected_w_plots = {

--- a/app/api_alpha/tests/test_buildings.py
+++ b/app/api_alpha/tests/test_buildings.py
@@ -1532,7 +1532,7 @@ class BuildingsWithPlots(APITestCase):
         def list_buildings():
             self.client.get("/api/alpha/buildings/")
 
-        # 1 for the query, 1 to log the call in rest_framework_tracking_apirequestlog
+        # 1 for the buildings, 1 for the related addresses, 1 to log the call in rest_framework_tracking_apirequestlog
         self.assertNumQueries(3, list_buildings)
 
     def test_single_bdg(self):

--- a/app/batid/list_bdg.py
+++ b/app/batid/list_bdg.py
@@ -151,6 +151,9 @@ def list_bdgs(params, only_active=True) -> QuerySet:
         )
         qs = qs.annotate(plots=PlotsAggSubquery(subquery))
 
+    # to prevent an ugly N+1 problem on the addresses
+    qs = qs.prefetch_related("addresses_read_only")
+
     return qs
 
 


### PR DESCRIPTION
Détecté par [Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/140968/?project=148&query=&referrer=project-issue-stream) 

On passe de 22 queries en 572ms 
![Capture d’écran 2025-01-07 à 17 17 24](https://github.com/user-attachments/assets/feff6801-eeb9-48dc-9d09-adf2ba732e47)


à 3 queries en 172ms (en local)
![Capture d’écran 2025-01-07 à 17 17 42](https://github.com/user-attachments/assets/e8655dfa-0ece-4134-b02c-92cd81786734)

Avec une ligne de code.

yay!