### PR TITLE
Encore des N+1 (endpoint guess) => 🗑️ 

### DIFF
--- a/app/batid/services/guess_bdg.py
+++ b/app/batid/services/guess_bdg.py
@@ -38,7 +38,7 @@ class BuildingGuess:
         # Filters
         # ###################
 
-        selects = ["b.id", "b.rnb_id"]
+        selects = ["b.id", "b.rnb_id", "b.status", "b.ext_ids"]
         wheres = ["is_active = TRUE"]
         joins = []
         group_by = None


### PR DESCRIPTION
Cette fois ci c'est sur le endpoint de guess, on passe de 43 requêtes à 3 et ça divise le temps de la requête par deux environ.

Avant (1145ms) :
![Capture d’écran 2025-01-08 à 16 25 42](https://github.com/user-attachments/assets/974166aa-2254-4883-9ce0-6711b1fa1250)

Après (504ms) :
![Capture d’écran 2025-01-08 à 16 25 07](https://github.com/user-attachments/assets/dd11337a-c2aa-4589-b861-3422e003aaef)
