### PR TITLE
API : rendre les commentaires optionnels 

### DIFF
--- a/app/api_alpha/serializers.py
+++ b/app/api_alpha/serializers.py
@@ -234,7 +234,7 @@ class BuildingUpdateSerializer(serializers.Serializer):
         allow_empty=True,
         required=False,
     )
-    comment = serializers.CharField(min_length=4, required=True)
+    comment = serializers.CharField(required=False, allow_blank=True)
 
     def validate(self, data):
         if data.get("is_active") is not None and (

--- a/app/api_alpha/tests/test_buildings.py
+++ b/app/api_alpha/tests/test_buildings.py
@@ -1138,7 +1138,6 @@ class BuildingPatchTest(APITestCase):
         self.assertEqual(r.status_code, 400)
 
         # update status and addresses
-
         data = {
             "status": "constructed",
             "addresses_cle_interop": [self.adr1.id, self.adr2.id],
@@ -1152,7 +1151,7 @@ class BuildingPatchTest(APITestCase):
 
         self.assertEqual(r.status_code, 204)
 
-        # comment is mandatory
+        # comment is not mandatory
         data = {
             "status": "constructed",
             "addresses_cle_interop": [self.adr1.id, self.adr2.id],
@@ -1163,7 +1162,7 @@ class BuildingPatchTest(APITestCase):
             data=json.dumps(data),
             content_type="application/json",
         )
-        self.assertEqual(r.status_code, 400)
+        self.assertEqual(r.status_code, 204)
 
         data = {
             "status": "constructed",
@@ -1174,7 +1173,7 @@ class BuildingPatchTest(APITestCase):
             data=json.dumps(data),
             content_type="application/json",
         )
-        self.assertEqual(r.status_code, 400)
+        self.assertEqual(r.status_code, 204)
 
         # can either deactivate or update
         data = {

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -853,7 +853,7 @@ class SingleBuilding(APIView):
                                         "description": """Liste des clés d'interopérabilité BAN liées au bâtiments. Si ce paramêtre est absent, les clés ne sont pas modifiées. Si le paramêtre est présent et que sa valeur est une liste vide, le bâtiment ne sera plus lié à une adresse.<br /><br /> Exemple: ["75105_8884_00004", "75105_8884_00006"]""",
                                     },
                                 },
-                                "required": ["comment"],
+                                "required": [],
                             }
                         }
                     },
@@ -876,7 +876,7 @@ class SingleBuilding(APIView):
             with transaction.atomic():
                 contribution = Contribution(
                     rnb_id=rnb_id,
-                    text=data["comment"],
+                    text=data.get("comment"),
                     status="fixed",
                     status_changed_at=datetime.now(),
                     review_user=user,


### PR DESCRIPTION
on devait toujours écrire un commentaire pour écrire dans le RNB, on a eu comme retour que c'était contraignant et souvent inutile.