### PR TITLE
Import BD Topo : fix

### DIFF
--- a/app/batid/services/imports/import_bdtopo.py
+++ b/app/batid/services/imports/import_bdtopo.py
@@ -37,6 +37,11 @@ def create_bdtopo_full_import_tasks(dpt_list: list, release_date: str) -> list:
         dpt_tasks = create_bdtopo_dpt_import_tasks(dpt, release_date, bulk_launch_uuid)
         tasks.extend(dpt_tasks)
 
+    # Those inspections are commented out for now since we want to verify the created candidates first
+    # inspect_tasks = create_inspection_tasks()
+    # inspect_group = group(*inspect_tasks)
+    # tasks.append(inspect_group)
+
     return tasks
 
 
@@ -61,11 +66,6 @@ def create_bdtopo_dpt_import_tasks(
         immutable=True,
     )
     tasks.append(convert_task)
-
-    # Those inspections are commented out for now since we want to verify the created candidates first
-    inspect_tasks = create_inspection_tasks()
-    inspect_group = group(*inspect_tasks)
-    tasks.append(inspect_group)
 
     return tasks
 

--- a/app/batid/services/imports/import_bdtopo.py
+++ b/app/batid/services/imports/import_bdtopo.py
@@ -9,7 +9,6 @@ from typing import Optional
 
 import fiona
 import psycopg2
-from celery import group
 from celery import Signature
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.geos import WKTWriter
@@ -19,7 +18,6 @@ from django.db import transaction
 from batid.models import Building
 from batid.models import BuildingImport
 from batid.models import Candidate
-from batid.services.candidate import create_inspection_tasks
 from batid.services.imports import building_import_history
 from batid.services.source import BufferToCopy
 from batid.services.source import Source


### PR DESCRIPTION
La création des 300+ tâches liées à l'import de la BD Topo ont fait crasher le serveur. J'ai pu reproduire le bug en local. Dès que je tentais de lancer plus 5 départements, la fonction de création des tâches n'aboutissait pas. La création des 300 tâches a très probablement fait saturer la mémoire du serveur et aurait conduit au crash.

Le souci vient de l'utilisation de plusieurs `group` de tâches Celery. Pour chaque département, on créait une tâche pour le téléchargement de la donnée, une tâche pour l'import puis un groupe de tâches pour l'inspection. Il semble qu'on ne [puisse pas chaîner plusieurs groups](https://stackoverflow.com/questions/15123772/celery-chaining-groups-and-subtasks-out-of-order-execution) dans Celery.

Pour corriger, je déclenche un seul groupe d'inspection à la fin de l'import de tous les départements plutot qu'un groupe d'inspection pour chaque départemetns. 
Aussi, pour ce trimestre, je commente ce groupe d'inspection afin que l'on vérifie à la main ce que donnera l'import de la bd topo.