### PR TITLE
Add remote debugging by default in dev docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - '8888:8888' # Jupyter notebook
       - '5678:5678'
-    command: python -m debugpy --wait-for-client --listen 0.0.0.0:5678 manage.py runserver 0.0.0.0:8000
+    command: python -m debugpy --listen 0.0.0.0:5678 manage.py runserver 0.0.0.0:8000
     volumes:
       - ./source_data:/data/downloads
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       service: web
     ports:
       - '8888:8888' # Jupyter notebook
+      - '5678:5678'
+    command: python -m debugpy --wait-for-client --listen 0.0.0.0:5678 manage.py runserver 0.0.0.0:8000
     volumes:
       - ./source_data:/data/downloads
     env_file:


### PR DESCRIPTION
Pas sûr que ce soit utile, vu que je viens de setup mon environnement je peux avoir raté quelque chose, mais j'ai l'impression que ça m'étais nécessaire pour remote-debug avec VSCode