### PR TITLE
Consommation de mémoire plus basse lors de l'import du cadastre

### DIFF
--- a/app/batid/services/imports/import_plots.py
+++ b/app/batid/services/imports/import_plots.py
@@ -20,7 +20,7 @@ from batid.services.administrative_areas import dpt_list_overseas
 from batid.services.source import Source
 
 
-def import_etalab_plots(dpt: str, release_date: str):
+def import_etalab_plots(dpt: str, release_date: str, batch_size: int = 100_000):
     """Import plots from Etalab"""
     print(
         f"---- Importing Etalab plots for departement {dpt} - release date {release_date} ----"
@@ -39,7 +39,6 @@ def import_etalab_plots(dpt: str, release_date: str):
         features = ijson.items(f, "features.item", use_float=True)
 
         batch = []
-        batch_size = 100000
 
         for feature in features:
 

--- a/app/batid/services/imports/import_plots.py
+++ b/app/batid/services/imports/import_plots.py
@@ -33,9 +33,7 @@ def import_etalab_plots(dpt: str, release_date: str):
     with open(src.path) as f, transaction.atomic():
 
         # Deleting all plots in the dpt
-        print("deleting plots with id starting with", dpt)
         Plot.objects.filter(id__startswith=dpt).delete()
-        print("plots deleted")
 
         # Then, importing the new plots
         features = ijson.items(f, "features.item", use_float=True)
@@ -57,8 +55,6 @@ def import_etalab_plots(dpt: str, release_date: str):
         if batch:
             _save_plots(batch)
 
-        print("plots saved")
-
         # remove the file
         os.remove(src.path)
 
@@ -69,8 +65,6 @@ def _save_plots(rows):
     writer = csv.writer(f, quoting=csv.QUOTE_MINIMAL)
     writer.writerows(rows)
     f.seek(0)
-
-    print("copy to db")
 
     with connection.cursor() as cursor:
         cursor.copy_from(

--- a/app/batid/tasks.py
+++ b/app/batid/tasks.py
@@ -135,9 +135,6 @@ def queue_full_plots_import(
     dpt_end: Optional[str] = None,
     released_before: Optional[str] = None,
 ):
-    notify_tech(
-        f"Queuing full plots (cadastre) import tasks.  Dpt start: {dpt_start}, dpt end: {dpt_end}.  Released before: {released_before}"
-    )
 
     all_plots_dpts = etalab_dpt_list()
     dpts = slice_dpts(all_plots_dpts, dpt_start, dpt_end)
@@ -149,6 +146,9 @@ def queue_full_plots_import(
         release_date = etalab_recent_release_date(before_date)
     else:
         release_date = etalab_recent_release_date()
+
+    msg = f"Import du cadastre Etalab. Départements: {dpt_start} à {dpt_end}. Date de sortie: {release_date}"
+    notify_tech(msg)
 
     tasks = create_plots_full_import_tasks(dpts, release_date)
 

--- a/app/batid/tests/test_import_plots.py
+++ b/app/batid/tests/test_import_plots.py
@@ -25,7 +25,7 @@ class ImportPlotsTestCase(TestCase):
         source_instance.path = fixture_path
 
         # launch the import
-        import_plots.import_etalab_plots("75", "2024-12-13")
+        import_plots.import_etalab_plots("75", "2024-12-13", 1)
 
         self.assertEqual(Plot.objects.count(), 3)
 


### PR DESCRIPTION
Le 30/01 l'import automatique du cadastre a crashé : 

```bash
Traceback (most recent call last):
File "/python_venv/app-9TtSrW0h-py3.12/lib/python3.12/site-packages/billiard/pool.py", line 1265, in mark_as_worker_lost raise WorkerLostError(billiard.exceptions.WorkerLostError: Worker exited prematurely: signal 9 (SIGKILL) Job: 4.
```

J'ai pu reproduire cette erreur en local en réduisant la mémoire disponible pour le worker. Dans le docker-compose.yml, sous `worker`:

```yml
    deploy:
      resources:
        limits:
          memory: 2024M
```

L'erreur venait de la création en mémoire d'un CSV contenant toutes les parcelles à importer. En découpant cette partie en batch de 100000 lignes on divise par deux la consommation de mémoire.

