### PR TITLE
Correction import Wallis et Futuna

### DIFF
--- a/app/batid/management/commands/sandbox.py
+++ b/app/batid/management/commands/sandbox.py
@@ -4,6 +4,4 @@ from django.core.management.base import BaseCommand
 class Command(BaseCommand):
     def handle(self, *args, **kwargs):
 
-        "https://data.geopf.fr/telechargement/download/BDTOPO/BDTOPO_3-4_TOUSTHEMES_SHP_LAMB93_D986_2024-12-15/BDTOPO_3-4_TOUSTHEMES_SHP_LAMB93_D986_2024-12-15.7z"
-
         pass

--- a/app/batid/management/commands/sandbox.py
+++ b/app/batid/management/commands/sandbox.py
@@ -4,4 +4,6 @@ from django.core.management.base import BaseCommand
 class Command(BaseCommand):
     def handle(self, *args, **kwargs):
 
+        "https://data.geopf.fr/telechargement/download/BDTOPO/BDTOPO_3-4_TOUSTHEMES_SHP_LAMB93_D986_2024-12-15/BDTOPO_3-4_TOUSTHEMES_SHP_LAMB93_D986_2024-12-15.7z"
+
         pass

--- a/app/batid/services/imports/import_bdtopo.py
+++ b/app/batid/services/imports/import_bdtopo.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from datetime import timezone
 from typing import Optional
 
-
 import fiona
 import psycopg2
 from celery import Signature
@@ -19,11 +18,11 @@ from django.db import transaction
 from batid.models import Building
 from batid.models import BuildingImport
 from batid.models import Candidate
+from batid.services.administrative_areas import dpts_list
 from batid.services.imports import building_import_history
 from batid.services.source import BufferToCopy
 from batid.services.source import Source
 from batid.utils.geo import fix_nested_shells
-from batid.services.administrative_areas import dpts_list
 
 
 def create_bdtopo_full_import_tasks(dpt_list: list, release_date: str) -> list:

--- a/app/batid/services/imports/import_bdtopo.py
+++ b/app/batid/services/imports/import_bdtopo.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from datetime import timezone
 from typing import Optional
 
+
 import fiona
 import psycopg2
 from celery import Signature
@@ -22,6 +23,7 @@ from batid.services.imports import building_import_history
 from batid.services.source import BufferToCopy
 from batid.services.source import Source
 from batid.utils.geo import fix_nested_shells
+from batid.services.administrative_areas import dpts_list
 
 
 def create_bdtopo_full_import_tasks(dpt_list: list, release_date: str) -> list:
@@ -270,3 +272,10 @@ def _bdtopo_release_dates() -> list:
         "2030-09-15",
         "2030-12-15",
     ]
+
+
+def bdtopo_dpt_list():
+
+    # Wallis-et-Futuna (986) and Polynésie française (987) are not available in BD Topo
+    all_dpts = dpts_list()
+    return [dpt for dpt in all_dpts if dpt not in ["986", "987"]]

--- a/app/batid/services/imports/import_bdtopo.py
+++ b/app/batid/services/imports/import_bdtopo.py
@@ -274,7 +274,7 @@ def _bdtopo_release_dates() -> list:
     ]
 
 
-def bdtopo_dpt_list():
+def bdtopo_dpts_list():
 
     # Wallis-et-Futuna (986) and Polynésie française (987) are not available in BD Topo
     all_dpts = dpts_list()

--- a/app/batid/tasks.py
+++ b/app/batid/tasks.py
@@ -24,7 +24,10 @@ from batid.services.data_gouv_publication import get_area_publish_task
 from batid.services.data_gouv_publication import publish
 from batid.services.imports.import_bdnb_2023_01 import import_bdnd_2023_01_addresses
 from batid.services.imports.import_bdnb_2023_01 import import_bdnd_2023_01_bdgs
-from batid.services.imports.import_bdtopo import bdtopo_recente_release_date
+from batid.services.imports.import_bdtopo import (
+    bdtopo_dpts_list,
+    bdtopo_recente_release_date,
+)
 from batid.services.imports.import_bdtopo import create_bdtopo_full_import_tasks
 from batid.services.imports.import_bdtopo import create_candidate_from_bdtopo
 from batid.services.imports.import_cities import import_etalab_cities
@@ -105,7 +108,7 @@ def queue_full_bdtopo_import(
     )
 
     # Get list of dpts
-    dpts = dpts_list(dpt_start, dpt_end)
+    dpts = bdtopo_dpts_list(dpt_start, dpt_end)
 
     # Default release date to most recent one
     if released_before:

--- a/app/batid/tasks.py
+++ b/app/batid/tasks.py
@@ -24,10 +24,8 @@ from batid.services.data_gouv_publication import get_area_publish_task
 from batid.services.data_gouv_publication import publish
 from batid.services.imports.import_bdnb_2023_01 import import_bdnd_2023_01_addresses
 from batid.services.imports.import_bdnb_2023_01 import import_bdnd_2023_01_bdgs
-from batid.services.imports.import_bdtopo import (
-    bdtopo_dpts_list,
-    bdtopo_recente_release_date,
-)
+from batid.services.imports.import_bdtopo import bdtopo_dpts_list
+from batid.services.imports.import_bdtopo import bdtopo_recente_release_date
 from batid.services.imports.import_bdtopo import create_bdtopo_full_import_tasks
 from batid.services.imports.import_bdtopo import create_candidate_from_bdtopo
 from batid.services.imports.import_cities import import_etalab_cities


### PR DESCRIPTION
Le téléchargement de la BD Topo pour Wallis et Futuna n'a pas marché. Sur le site de l'IGN, je vois quela BD Topo n'est pas disponible pour Wallis et Futuna ainsi que pour la Polynésie française.

