### PR TITLE
Ne compter que les signalements 'pending' dans les tuiles carto

### DIFF
--- a/app/batid/services/vector_tiles.py
+++ b/app/batid/services/vector_tiles.py
@@ -142,7 +142,7 @@ def envelopeToBuildingsSQL(env, geometry_column):
         ),
         mvtgeom AS (
             SELECT ST_AsMVTGeom(ST_Transform(t.{geomColumn}, 3857), bounds.b2d) AS geom,
-                   {attrColumns}, (select count(*) from batid_contribution c where c.rnb_id = t.rnb_id) as contributions
+                   {attrColumns}, (select count(*) from batid_contribution c where c.rnb_id = t.rnb_id and c.status = 'pending') as contributions
             FROM {table} t, bounds
             WHERE ST_Intersects(t.{geomColumn}, ST_Transform(bounds.geom, {srid}))
             and t.is_active = true


### PR DESCRIPTION
Signalé par Ines, un bâtiment continue à apparaitre en rose sur notre site internet même lorsque le signalement a été traitée.