### PR TITLE
Synchroniser le déploiement sur la prod et sur sandbox

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,15 +1,15 @@
-name: Deploy application on production server
+name: Deploy application on production & sandbox servers
 on:
     push:
         branches:
             - main
 jobs:
     deployment:
-        name: Deployment on production server
+        name: Deployment on production & sandbox servers
         runs-on: ubuntu-latest
         environment: production
         steps:
-            - name: connect to server with ssh and run commands to deploy
+            - name: connect to the production server with ssh and run commands to deploy
               uses: appleboy/ssh-action@v1.0.0
               with:
                   host: ${{ secrets.SSH_HOST }}
@@ -17,3 +17,11 @@ jobs:
                   key: ${{ secrets.SSH_PRIVATE_KEY }}
                   port: ${{ secrets.SSH_PORT }}
                   script: cd /srv/RNB-coeur && git pull && docker compose -f docker-compose.prod.yml build --no-cache && docker compose -f docker-compose.prod.yml up -d
+            - name: connect to the sandbox server with ssh and run commands to deploy
+              uses: appleboy/ssh-action@v1.0.0
+              with:
+                  host: ${{ secrets.SANDBOX_SSH_HOST }}
+                  username: ${{ secrets.SSH_USERNAME }}
+                  key: ${{ secrets.SSH_PRIVATE_KEY }}
+                  port: ${{ secrets.SSH_PORT }}
+                  script: cd /srv/RNB-coeur && git pull && docker compose -f docker-compose.sandbox.yml build --no-cache && docker compose -f docker-compose.sandbox.yml up -d


### PR DESCRIPTION
J'ajoute le déploiement sur sandbox depuis les github actions.
Les clés sont les mêmes, c'est l'IP du serveur qui change.
J'ai rajouté un secret dans le repo pour l'IP du serveur de sandbox