### PR TITLE
Afficher les BuildingImport dans le backoffice

### DIFF
--- a/app/batid/admin.py
+++ b/app/batid/admin.py
@@ -6,10 +6,10 @@ from jsoneditor.forms import JSONEditor
 
 from batid.models import Address
 from batid.models import ADS
+from batid.models import BuildingImport
 from batid.models import Contribution
 from batid.models import DiffusionDatabase
 from batid.models import Organization
-from batid.models import BuildingImport
 from batid.views import export_ads
 from batid.views import export_contributions
 from batid.views import worker

--- a/app/batid/admin.py
+++ b/app/batid/admin.py
@@ -28,6 +28,7 @@ class BuildingImportAdmin(admin.ModelAdmin):
         "import_source",
         "departement",
         "created_at",
+        "updated_at",
         "candidate_created_count",
         "building_created_count",
         "building_updated_count",


### PR DESCRIPTION
Mini PR : on affiche les BuildingImport dans le BO de django pour un suivi un peu plus facile des différents imports.

<img width="2119" alt="Capture d’écran 2025-04-09 à 16 44 07" src="https://github.com/user-attachments/assets/90778a13-5d06-4116-ac20-58d3263a71fb" />
