### PR TITLE
Publication sur data.gouv : faire échouer la tâche en cas de problème

### DIFF
--- a/app/batid/services/data_gouv_publication.py
+++ b/app/batid/services/data_gouv_publication.py
@@ -33,7 +33,7 @@ def publish(areas_list):
             logging.error(
                 f"Error while publishing the RNB for area {area} on data.gouv.fr: {e}"
             )
-            return False
+            raise
         finally:
             # we always cleanup the directory, no matter what happens
             cleanup_directory(directory_name)


### PR DESCRIPTION
Pour le moment on avait un try...except qui log un message d'erreur, mais qui ne re-raise pas, ce qui fait apparaitre la tache comme ayant réussi dans Flower et qui nous cache la stack trace.

Je voudrais relancer la publi nationale avec ce changement pour voir à quel niveau la publication échoue.