### PR TITLE
Fix dans la conf de celery beat

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/3.0/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.0/ref/settings/
 """
+
 import os
 
 import sentry_sdk
@@ -258,7 +259,7 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(minute=0, hour=0, day_of_month="1,15"),
     },
     "create_bal_links": {
-        "tasks": "batid.tasks.queue_full_bal_rnb_links",
+        "task": "batid.tasks.queue_full_bal_rnb_links",
         # we create links after the BAN has been imported
         "schedule": crontab(minute=0, hour=0, day_of_month="2,16"),
     },

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -9,7 +9,6 @@ https://docs.djangoproject.com/en/3.0/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.0/ref/settings/
 """
-
 import os
 
 import sentry_sdk

--- a/app/batid/tasks.py
+++ b/app/batid/tasks.py
@@ -344,10 +344,3 @@ def queue_full_bal_rnb_links(
 def create_dpt_bal_rnb_links(src_params: dict, bulk_launch_uuid: Optional[str] = None):
 
     return create_dpt_bal_rnb_links_job(src_params, bulk_launch_uuid)
-
-
-# create a task to display current dateime
-@shared_task
-def display_current_datetime():
-
-    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/app/batid/tasks.py
+++ b/app/batid/tasks.py
@@ -344,3 +344,10 @@ def queue_full_bal_rnb_links(
 def create_dpt_bal_rnb_links(src_params: dict, bulk_launch_uuid: Optional[str] = None):
 
     return create_dpt_bal_rnb_links_job(src_params, bulk_launch_uuid)
+
+
+# create a task to display current dateime
+@shared_task
+def display_current_datetime():
+
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
Cette très grosse PR modifie en profondeur la configuration de celery beat.
Plus sérieusement, c'est notre meilleure piste pour expliquer le fait que les tâches qui devaient avoir lieu dans la nuit du 14 au 15 avril n'ont pas eu lieu du tout.

Il n'est pas certain que ce soit la solution mais de toute façon c'est une erreur.