### PR TITLE
Réparer le formulaire de création de user dans Django admin

### DIFF
--- a/app/batid/admin.py
+++ b/app/batid/admin.py
@@ -1,4 +1,8 @@
+from django import forms
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.models import User
 from django.db.models.fields.json import JSONField
 from django.urls import path
 from django.utils.html import format_html
@@ -127,3 +131,26 @@ def get_admin_urls(urls):
 
 
 admin.site.get_urls = get_admin_urls(admin.site.get_urls())
+
+
+class CustomUserCreationForm(UserCreationForm):
+    email = forms.EmailField(required=True)
+
+    class Meta:
+        model = User
+        fields = ("username", "email", "password1", "password2")
+
+
+BaseUserAdmin.add_form = CustomUserCreationForm
+BaseUserAdmin.add_fieldsets = (
+    (
+        None,
+        {
+            "classes": ("wide",),
+            "fields": ("username", "email", "password1", "password2"),
+        },
+    ),
+)
+
+admin.site.unregister(User)
+admin.site.register(User, BaseUserAdmin)

--- a/app/batid/admin.py
+++ b/app/batid/admin.py
@@ -151,6 +151,3 @@ BaseUserAdmin.add_fieldsets = (
         },
     ),
 )
-
-admin.site.unregister(User)
-admin.site.register(User, BaseUserAdmin)

--- a/app/batid/tests/test_admin.py
+++ b/app/batid/tests/test_admin.py
@@ -1,0 +1,14 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+
+class UserCreationForm(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser(
+            username="foobar", email="foo@bar.com", password="barbaz"
+        )
+        self.client.force_login(user=self.user)
+
+    def test_has_email_field(self):
+        response = self.client.get("/admin/auth/user/add/")
+        self.assertContains(response, "email")


### PR DESCRIPTION
Maintenant que l'email est obligatoire, il faut rajouter le champ au formulaire de création d'un User.

![Capture d’écran 2025-04-23 à 14 01 02](https://github.com/user-attachments/assets/73e2496b-6e79-468f-8c3a-ad770652031c)
