### PR TITLE
Vitesse du endpoint de listing de bâtiments

### DIFF
--- a/app/api_alpha/tests/test_pagination.py
+++ b/app/api_alpha/tests/test_pagination.py
@@ -1,6 +1,6 @@
-from batid.models import Building
 from rest_framework.test import APITestCase
 
+from batid.models import Building
 from batid.tests.helpers import create_default_bdg
 from batid.tests.helpers import create_grenoble
 

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -44,6 +44,7 @@ from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.exceptions import NotFound
 from rest_framework.exceptions import ParseError
 from rest_framework.pagination import BasePagination
+from rest_framework.pagination import CursorPagination
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import BasePermission
 from rest_framework.renderers import JSONRenderer
@@ -522,6 +523,11 @@ class BuildingAddressView(RNBLoggingMixin, APIView):
             return Response(query_serializer.errors, status=400)
 
 
+class RNBCursorPagination(CursorPagination):
+    page_size = 20
+    ordering = "id"
+
+
 class BuildingCursorPagination(BasePagination):
     page_size = 20
 
@@ -762,10 +768,13 @@ class ListCreateBuildings(RNBLoggingMixin, APIView):
         # add user to query params
         query_params["user"] = request.user
         buildings = list_bdgs(query_params)
-        paginator = BuildingCursorPagination()
+
+        # paginator = BuildingCursorPagination()
+        paginator = RNBCursorPagination()
 
         # paginate
         paginated_buildings = paginator.paginate_queryset(buildings, request)
+
         serializer = BuildingSerializer(
             paginated_buildings, with_plots=with_plots, many=True
         )


### PR DESCRIPTION
On nous a indiqué que sur `/api/alpha/buildings`, plus on avançait dans les pages et plus les requêtes étaient lentes.

Par ailleurs le code de ce endpoint était était assez confus : 
- en temps normal, on triait par ID
- lors d'une requête géographique (`bbox` ou `insee_code`) on triait par `created_at` pour défavoriser l'index contenant l'id et favoriser l'index contenant shape

La première étape de la solution a été de passer à une vraie pagination par curseur. En faisant cela, j'ai pu résoudre le problème d'avancée dans les pages en me débarrassant complètement de l'`OFFSET`. Les performances ne sont pas incroyables (il y a sans doute beaucoup d'optimisation possible) mais on passe d'inutilisable à utilisable.

Le problème est que cela a un peu plus favorisé l'index contenant l'id lors des requêtes. Dans le cas de requête géographiques, le query planner de Postgres se *trompe* et continue à utiliser l'index de l'id plutôt qu'un index spatial. Les performances de ces requêtes se retrouvent fortement dégradées.

Pour favoriser l'usage de l'index géographique, j'ai utilisé `__bboverlaps` de l'[ORM de Django](https://docs.djangoproject.com/en/5.1/ref/contrib/gis/geoquerysets/#bboverlaps). Cela équivaut à `shape && geom` de [PostGIS](https://postgis.net/docs/geometry_overlaps.html). Si j'ai bien compris, [cela force PostGIS](https://postgis.net/workshops/postgis-intro/indexing.html#index-only-queries) à utiliser un index spatial lors de la requête.

En combinant la pagination par curseur et `__bboverlaps` on arrive à des performances acceptables pour toutes les requêtes.