### PR TITLE
Fix updated_at lors import BAL

### DIFF
--- a/app/batid/models.py
+++ b/app/batid/models.py
@@ -202,6 +202,7 @@ class Building(BuildingAbstract):
         ext_ids: list | None = None,
         shape: GEOSGeometry | None = None,
     ):
+
         if (
             status is None
             and addresses_id is None

--- a/app/batid/services/imports/import_bal.py
+++ b/app/batid/services/imports/import_bal.py
@@ -97,7 +97,7 @@ def create_dpt_bal_rnb_links(src_params: dict, bulk_launch_uuid=None):
 def find_bdg_to_link(address_point: Point, cle_interop: str) -> Optional[Building]:
 
     sql = """
-        SELECT bdg.id, bdg.rnb_id, bdg.is_active,
+        SELECT bdg.id, bdg.rnb_id, bdg.is_active, bdg.updated_at,
         COALESCE (bdg.addresses_id, '{}') AS current_addresses,
         COALESCE(array_agg(DISTINCT unnested_address_id), '{}') AS past_addresses
         FROM batid_building as bdg
@@ -106,7 +106,7 @@ def find_bdg_to_link(address_point: Point, cle_interop: str) -> Optional[Buildin
         WHERE ST_Intersects(bdg.shape, %(address_point)s)
         AND bdg.status IN %(status)s
         AND bdg.is_active = TRUE
-        GROUP BY bdg.id, bdg.rnb_id, bdg.addresses_id, bdg.is_active
+        GROUP BY bdg.id, bdg.rnb_id, bdg.addresses_id, bdg.is_active, bdg.updated_at
     """
 
     params = {

--- a/app/batid/tests/test_bal_links.py
+++ b/app/batid/tests/test_bal_links.py
@@ -4,7 +4,8 @@ from unittest.mock import patch
 
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.geos import Point
-from django.test import TestCase, TransactionTestCase
+from django.test import TestCase
+from django.test import TransactionTestCase
 
 import batid.tests.helpers as helpers
 from batid.exceptions import BANUnknownCleInterop
@@ -16,7 +17,6 @@ from batid.services.imports.import_bal import find_bdg_to_link
 
 
 class BALImport(TransactionTestCase):
-
     def setUp(self):
 
         # Building ONE

--- a/app/batid/tests/test_bal_links.py
+++ b/app/batid/tests/test_bal_links.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.geos import Point
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 
 import batid.tests.helpers as helpers
 from batid.exceptions import BANUnknownCleInterop
@@ -15,13 +15,9 @@ from batid.services.imports.import_bal import create_dpt_bal_rnb_links
 from batid.services.imports.import_bal import find_bdg_to_link
 
 
-class BALImport(TestCase):
-    @patch("batid.services.imports.import_bal.Source.find")
-    def test_bal_import(self, source_mock):
+class BALImport(TransactionTestCase):
 
-        source_mock.return_value = helpers.copy_fixture(
-            "bal_import_test_data.csv", "bal_import_test_data_COPY.csv"
-        )
+    def setUp(self):
 
         # Building ONE
 
@@ -43,7 +39,7 @@ class BALImport(TestCase):
             ),
         )
 
-        Building.objects.create(
+        b_one = Building.objects.create(
             rnb_id="ONE",
             addresses_id=["OLD_ON_ONE"],
             status="constructed",
@@ -96,6 +92,15 @@ class BALImport(TestCase):
             ),
         )
 
+    @patch("batid.services.imports.import_bal.Source.find")
+    def test_bal_import(self, source_mock):
+
+        source_mock.return_value = helpers.copy_fixture(
+            "bal_import_test_data.csv", "bal_import_test_data_COPY.csv"
+        )
+
+        old_updated_at = Building.objects.get(rnb_id="ONE").updated_at
+
         # We execute the BAL import
         bulk_launch_uuid = uuid.uuid4()
 
@@ -111,10 +116,15 @@ class BALImport(TestCase):
 
         # We check the buildings
         bdg_one = Building.objects.get(rnb_id="ONE")
+        new_updated_at = bdg_one.updated_at
+
         self.assertListEqual(bdg_one.addresses_id, ["OLD_ON_ONE", "GO_ON_ONE"])
         self.assertDictEqual(
             bdg_one.event_origin, {"source": "import", "id": report.id}
         )
+
+        # We check the updated_at field has changed automatically
+        self.assertNotEqual(old_updated_at, new_updated_at)
 
         bdg_two = Building.objects.get(rnb_id="TWO")
         self.assertListEqual(bdg_two.addresses_id, ["GO_ON_TWO"])

--- a/app/batid/tests/test_models.py
+++ b/app/batid/tests/test_models.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 
+from django.contrib.gis.geos import GEOSGeometry
 from django.db.utils import IntegrityError
 from django.test import override_settings
 from django.test import TestCase
@@ -9,8 +10,6 @@ from batid.models import Address
 from batid.models import Building
 from batid.models import Contribution
 from batid.models import User
-from django.contrib.gis.geos import GEOSGeometry
-from django.contrib.gis.geos import GEOSGeometry
 
 
 class TestBuilding(TestCase):
@@ -340,7 +339,6 @@ class TestSplitBuilding(TestCase):
 
 
 class TestUpdateBuilding(TestCase):
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/app/batid/tests/test_models.py
+++ b/app/batid/tests/test_models.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 
 from django.db.utils import IntegrityError
 from django.test import override_settings
@@ -8,6 +9,8 @@ from batid.models import Address
 from batid.models import Building
 from batid.models import Contribution
 from batid.models import User
+from django.contrib.gis.geos import GEOSGeometry
+from django.contrib.gis.geos import GEOSGeometry
 
 
 class TestBuilding(TestCase):
@@ -334,3 +337,69 @@ class TestSplitBuilding(TestCase):
                 self.user,
                 event_origin,
             )
+
+
+class TestUpdateBuilding(TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.rnb_id = None
+        self.user = None
+
+    def setUp(self):
+
+        Address.objects.create(id="addr1")
+        Address.objects.create(id="addr2")
+        Address.objects.create(id="addr3")
+
+        self.user = User.objects.create_user(username="solo_user")
+
+        b = Building.create_new(
+            user=self.user,
+            event_origin={"source": "dummy_creation"},
+            status="constructed",
+            addresses_id=["addr1", "addr2"],
+            shape=GEOSGeometry(
+                json.dumps(
+                    {
+                        "coordinates": [
+                            [
+                                [-0.5629838649124963, 44.89830737784746],
+                                [-0.5627894800164768, 44.89622105788288],
+                                [-0.5603213808721534, 44.89635458462783],
+                                [-0.5605098753173934, 44.89844507230214],
+                                [-0.5629838649124963, 44.89830737784746],
+                            ]
+                        ],
+                        "type": "Polygon",
+                    }
+                )
+            ),
+            ext_ids=[],
+        )
+
+        self.rnb_id = b.rnb_id
+
+    def test_updated_at(self):
+        """
+        Test that the updated_at field is set when updating a building.
+        """
+        b = Building.objects.get(rnb_id=self.rnb_id)
+        old_updated_at = b.updated_at
+
+        print(f"Old updated_at: {old_updated_at}")
+
+        # Update the building
+
+        b.update(
+            user=self.user,
+            status="demolished",
+            event_origin={"source": "dummy_update"},
+            addresses_id=None,
+        )
+
+        b.refresh_from_db()
+
+        print(f"New updated_at: {b.updated_at}")
+        self.assertNotEqual(b.updated_at, old_updated_at)


### PR DESCRIPTION
En vérifiant le résultat des imports de la BAL de cette nuit, j'ai remarqué que le champ `updated_at` des bâtiments mis à jour n'avait pas changé.

L'origine du problème était dans le `SELECT ...` utilisé dans l'import des BAL qui ne contenait pas le champ `updated_at`. Cela faisait dérailler le fonctionnement de `auto_now=True` défini dans le model.