### PR TITLE
Make sure Dependabot runs on all project scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/nginx/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/app/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Scan GitHub actions, Docker compose, individual Dockerfile in addition to Python dependencies