### PR TITLE
MAJ page de stats

### DIFF
--- a/app/api_alpha/tests/test_views.py
+++ b/app/api_alpha/tests/test_views.py
@@ -32,8 +32,10 @@ class StatsTest(APITestCase):
         # trigger the stats computation for building count
         compute_today_kpis()
 
-        # create one contribution
-        Contribution.objects.create()
+        # create one "report" (signalement) contribution
+        Contribution.objects.create(report=True)
+        # and one edition
+        Contribution.objects.create(report=False)
 
         # log 2 API request, one is older than 2024
         APIRequestLog.objects.create(requested_at="2023-01-01T00:00:00Z")
@@ -51,6 +53,7 @@ class StatsTest(APITestCase):
         self.assertLess(results["building_counts"], 4)
         self.assertEqual(results["api_calls_since_2024_count"], 1)
         self.assertEqual(results["contributions_count"], 1)
+        self.assertEqual(results["editions_count"], 1)
         self.assertEqual(results["data_gouv_publication_count"], 11)
 
         # assert the mock was called

--- a/app/api_alpha/tests/test_views.py
+++ b/app/api_alpha/tests/test_views.py
@@ -37,6 +37,8 @@ class StatsTest(APITestCase):
         # and one edition
         Contribution.objects.create(report=False)
 
+        DiffusionDatabase.objects.create()
+
         # log 2 API request, one is older than 2024
         APIRequestLog.objects.create(requested_at="2023-01-01T00:00:00Z")
         APIRequestLog.objects.create(requested_at="2024-01-02T00:00:00Z")
@@ -55,6 +57,7 @@ class StatsTest(APITestCase):
         self.assertEqual(results["contributions_count"], 1)
         self.assertEqual(results["editions_count"], 1)
         self.assertEqual(results["data_gouv_publication_count"], 11)
+        self.assertEqual(results["diffusion_databases_count"], 1)
 
         # assert the mock was called
         get_mock.assert_called_with("https://www.data.gouv.fr/api/1/datasets/?tag=rnb")

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -1947,6 +1947,7 @@ def get_stats(request):
     contributions_count = Contribution.objects.filter(report=True).count()
     editions_count = Contribution.objects.filter(report=False).count()
     data_gouv_publication_count = get_data_gouv_publication_count()
+    diffusion_databases_count = DiffusionDatabase.objects.count()
 
     # Get the cached value of the building count
     bdg_count_kpi = get_kpi_most_recent(KPI_ACTIVE_BUILDINGS_COUNT)
@@ -1957,6 +1958,7 @@ def get_stats(request):
         "contributions_count": contributions_count,
         "editions_count": editions_count,
         "data_gouv_publication_count": data_gouv_publication_count,
+        "diffusion_databases_count": diffusion_databases_count,
     }
 
     renderer = JSONRenderer()

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -1944,7 +1944,8 @@ def get_stats(request):
     api_calls_since_2024_count = APIRequestLog.objects.filter(
         requested_at__gte="2024-01-01T00:00:00Z"
     ).count()
-    contributions_count = Contribution.objects.count()
+    contributions_count = Contribution.objects.filter(report=True).count()
+    editions_count = Contribution.objects.filter(report=False).count()
     data_gouv_publication_count = get_data_gouv_publication_count()
 
     # Get the cached value of the building count
@@ -1954,6 +1955,7 @@ def get_stats(request):
         "building_counts": bdg_count_kpi.value,
         "api_calls_since_2024_count": api_calls_since_2024_count,
         "contributions_count": contributions_count,
+        "editions_count": editions_count,
         "data_gouv_publication_count": data_gouv_publication_count,
     }
 


### PR DESCRIPTION
suite à notre point de ce matin, maj du endpoint de stats:
- compter à part les signalements et les éditions
- compter le nombre de bases de données depuis notre table interne DiffusionDatabase et pas uniquement les jeux de données de data.gouv.fr