### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [the_import,main]
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/fab-geocommuns/RNB-coeur/security/code-scanning/9](https://github.com/fab-geocommuns/RNB-coeur/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Based on the provided steps, the workflow primarily interacts with the repository contents (e.g., checking out code) and does not appear to require write access. Therefore, we will set `contents: read` as the permission. If additional permissions are required in the future, they can be added explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
