### PR TITLE
Utiliser l'email dans le user ranking

### DIFF
--- a/app/api_alpha/tests/test_summerchallenge_api.py
+++ b/app/api_alpha/tests/test_summerchallenge_api.py
@@ -1,5 +1,6 @@
 import json
 from urllib.parse import quote
+
 from django.contrib.auth.models import User
 from django.contrib.gis.geos import GEOSGeometry
 from django.test import override_settings

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -1870,7 +1870,7 @@ def get_summer_challenge_leaderboard(request):
 def get_summer_challenge_user_score(request, username):
     global_score = summer_challenge_global_score()
     individual_ranking = (
-        SummerChallenge.objects.values("user__username")
+        SummerChallenge.objects.values("user__username", "user__email")
         .annotate(score=Sum("score"))
         .order_by("-score")
     )
@@ -1879,7 +1879,7 @@ def get_summer_challenge_user_score(request, username):
         user_index, user_info = next(
             (i, x)
             for i, x in enumerate(individual_ranking)
-            if x["user__username"] == username
+            if x["user__username"] == username or x["user__email"] == username
         )
     except StopIteration:
         raise NotFound()


### PR DESCRIPTION
Si on interrogeait le endpoint de ranking individuel avec un email (ce que le front fait quand on se log avec son email et qui est un autre problème méritant d'être réglé) alors on obtenait une 404.