### PR TITLE
Empecher les shapes vides

### DIFF
--- a/app/api_alpha/serializers.py
+++ b/app/api_alpha/serializers.py
@@ -278,6 +278,10 @@ def shape_is_valid(shape):
         raise serializers.ValidationError(
             "La forme fournie n'a pas pu être analysée ou n'est pas valide"
         )
+
+    if g.empty:
+        raise serializers.ValidationError("La forme fournie est vide")
+
     return shape
 
 

--- a/app/api_alpha/tests/buildings/test_creation.py
+++ b/app/api_alpha/tests/buildings/test_creation.py
@@ -28,6 +28,27 @@ class BuildingPostTest(APITestCase):
         self.adr1 = Address.objects.create(id="cle_interop_1")
         self.adr2 = Address.objects.create(id="cle_interop_2")
 
+    def test_empty_shape(self):
+        self.user.groups.add(self.group)
+        data = {
+            "status": "constructed",
+            "addresses_cle_interop": ["cle_interop_1", "cle_interop_2"],
+            "shape": "POLYGON EMPTY",
+            "comment": "nouveau bâtiment",
+        }
+
+        r = self.client.post(
+            f"/api/alpha/buildings/",
+            data=json.dumps(data),
+            content_type="application/json",
+        )
+
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(
+            r.json(),
+            {"shape": ["La forme fournie est vide"]},
+        )
+
     @override_settings(MAX_BUILDING_AREA=float("inf"))
     def test_create_building(self):
         data = {

--- a/app/api_alpha/tests/test_buildings.py
+++ b/app/api_alpha/tests/test_buildings.py
@@ -696,6 +696,25 @@ class BuildingPatchTest(APITestCase):
 
         self.assertEqual(r.status_code, 204)
 
+    def test_update_empty_shape(self):
+        self.user.groups.add(self.group)
+
+        data = {
+            "shape": "POlYGON EMPTY",
+        }
+
+        r = self.client.patch(
+            f"/api/alpha/buildings/{self.rnb_id}/",
+            data=json.dumps(data),
+            content_type="application/json",
+        )
+
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(
+            r.json(),
+            {"shape": ["La forme fournie est vide"]},
+        )
+
     def test_update_a_building_invalid_shape(self):
         self.user.groups.add(self.group)
 


### PR DESCRIPTION
On a eu le cas d'envoi d'une shape vide (ex : `POLYGON EMPTY`) via la carte. Cela a fait crashé ce bâtiment (500 quand le consulte via l'API).

Ce patch empêche l'envoi de shape vide