### PR TITLE
Point dans endpoint d'historique

### DIFF
--- a/app/api_alpha/serializers/building_history.py
+++ b/app/api_alpha/serializers/building_history.py
@@ -81,6 +81,7 @@ class BuildingHistorySerializer(serializers.Serializer):
     rnb_id = RNBIdField()
     is_active = serializers.BooleanField()
     shape = serializers.JSONField()
+    point = serializers.JSONField()
     status = serializers.CharField()
     event = BuildingEventSerializer()
     ext_ids = ExtIdSerializer(many=True)

--- a/app/api_alpha/tests/test_history.py
+++ b/app/api_alpha/tests/test_history.py
@@ -116,7 +116,7 @@ class SingleBuildingHistoryTest(APITestCase):
             {
                 "rnb_id": self.rnb_id,
                 "is_active": True,
-                "point": None,
+                "point": {"coordinates": [1.365534353, 48.732755114], "type": "Point"},
                 "shape": {
                     "type": "Polygon",
                     "coordinates": [

--- a/app/api_alpha/tests/test_history.py
+++ b/app/api_alpha/tests/test_history.py
@@ -116,6 +116,7 @@ class SingleBuildingHistoryTest(APITestCase):
             {
                 "rnb_id": self.rnb_id,
                 "is_active": True,
+                "point": None,
                 "shape": {
                     "type": "Polygon",
                     "coordinates": [

--- a/app/batid/services/bdg_history.py
+++ b/app/batid/services/bdg_history.py
@@ -10,6 +10,7 @@ def get_bdg_history(rnb_id: str) -> list[dict]:
     bdg.rnb_id,
     bdg.is_active,
     ST_AsGeoJSON(bdg.shape)::json AS shape,
+    ST_AsGeoJSON(bdg.point)::json AS point,
     bdg.status,
     bdg.ext_ids::json,
     lower(bdg.sys_period) AS updated_at,


### PR DESCRIPTION
En plus de `shape`, on ajoute `point` dans les attributs retournés par le endpoint d'historique. Cela permettra de générer plus facilement les liens vers le site de la BAN et le site Remonter le temps de l'IGN