### PR TITLE
MAJ vers Postgres 16

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -44,7 +44,7 @@ services:
     container_name: web
 
   db:
-    image: postgis/postgis:15-3.3
+    image: postgis/postgis:16-3.5
     platform: linux/amd64
     shm_size: 1gb
     volumes:


### PR DESCRIPTION
et Postgis 3.5, pour être en ligne avec les dernières versions disponibles sur Scaleway.

Pour connaitre les versions en commandes SQL :

```
SELECT PostGIS_Version();
select version();
```