### PR TITLE
Strengthen Docker containers

### DIFF
--- a/.env.worker.example
+++ b/.env.worker.example
@@ -4,7 +4,5 @@
 CELERY_BROKER_URL=amqp://guest:changemeplease!@rabbitmq//
 CELERY_RESULT_BACKEND=redis://redis:6379/0
 
-DOWNLOAD_DIR=/data/downloads
-
 # PG timeouts
 POSTGRES_STATEMENT_TIMEOUT=15000

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -45,7 +45,6 @@ RUN chown 999:999 /app/data
 USER app
 
 FROM base as app_web
-COPY entrypoint.sh ./
 ENTRYPOINT ["./entrypoint.sh"]
 
 FROM base as app_worker

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -27,7 +27,9 @@ RUN ln -s $(poetry env info --path) /venv
 ENV VIRTUAL_ENV=/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN useradd --no-create-home --system --uid 1000 --user-group worker
+RUN useradd --no-create-home --uid 2000 --user-group app
+
+USER app
 
 FROM base as app_web
 COPY entrypoint.sh ./

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -38,6 +38,10 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN groupadd -r -g 999 app && \
     useradd -r -g app -u 999 app
 
+COPY --chown=999:999 . /app
+RUN mkdir /app/data
+RUN chown 999:999 /app/data
+
 USER app
 
 FROM base as app_web

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -27,7 +27,16 @@ RUN ln -s $(poetry env info --path) /venv
 ENV VIRTUAL_ENV=/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN useradd --no-create-home --uid 2000 --user-group app
+# From Redis Dockerfile: https://github.com/redis/docker-library-redis/blob/master/Dockerfile.template#L12
+# -r creates a system user and group. 999 as uid/gid seems to be the default for system users.
+# From man:
+#   System users will be created with no aging information in /etc/shadow, and their numeric identifiers are choosen
+#   in the SYS_UID_MIN-SYS_UID_MAX range, defined in /etc/login.defs, instead of UID_MIN-UID_MAX (and their GID counterparts
+#   for the creation of groups).
+#   Note that useradd will not create a home directory for such an user, regardless of the default setting in /etc/login.defs
+#   (CREATE_HOME). You have to specify the -m options if you want a home directory for a system account to be created.
+RUN groupadd -r -g 999 app && \
+    useradd -r -g app -u 999 app
 
 USER app
 

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/3.0/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.0/ref/settings/
 """
+
 import os
 
 import sentry_sdk
@@ -17,6 +18,7 @@ from sentry_sdk.integrations.django import DjangoIntegration
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WRITABLE_DATA_DIR = os.path.join(BASE_DIR, "data")
 
 
 # Quick-start development settings - unsuitable for production

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -9,7 +9,6 @@ https://docs.djangoproject.com/en/3.0/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.0/ref/settings/
 """
-
 import os
 
 import sentry_sdk

--- a/app/batid/services/data_gouv_publication.py
+++ b/app/batid/services/data_gouv_publication.py
@@ -12,6 +12,7 @@ from celery import Signature
 from django.conf import settings
 from django.db import connection
 from django.db import transaction
+
 from app.settings import WRITABLE_DATA_DIR
 from batid.services.administrative_areas import dpts_list
 

--- a/app/batid/services/data_gouv_publication.py
+++ b/app/batid/services/data_gouv_publication.py
@@ -12,7 +12,7 @@ from celery import Signature
 from django.conf import settings
 from django.db import connection
 from django.db import transaction
-
+from app.settings import WRITABLE_DATA_DIR
 from batid.services.administrative_areas import dpts_list
 
 
@@ -44,8 +44,9 @@ def create_directory(area):
     directory_name = (
         f'datagouvfr_publication_{area}_{datetime.now().strftime("%Y-%m-%d_%H-%M-%S")}'
     )
-    os.mkdir(directory_name)
-    return directory_name
+    directory_path = os.path.join(WRITABLE_DATA_DIR, directory_name)
+    os.mkdir(directory_path)
+    return directory_path
 
 
 # Return the global path of a file WITHOUT the extension

--- a/app/batid/services/data_gouv_publication.py
+++ b/app/batid/services/data_gouv_publication.py
@@ -46,7 +46,7 @@ def create_directory(area):
         f'datagouvfr_publication_{area}_{datetime.now().strftime("%Y-%m-%d_%H-%M-%S")}'
     )
     directory_path = os.path.join(WRITABLE_DATA_DIR, directory_name)
-    os.mkdir(directory_path)
+    os.makedirs(directory_path, exist_ok=True)
     return directory_path
 
 

--- a/app/batid/services/source.py
+++ b/app/batid/services/source.py
@@ -8,6 +8,7 @@ import zipfile
 import nanoid
 import py7zr
 import requests
+
 from app.settings import WRITABLE_DATA_DIR
 
 

--- a/app/batid/services/source.py
+++ b/app/batid/services/source.py
@@ -3,8 +3,8 @@ import gzip
 import os
 import shutil
 import tarfile
-import zipfile
 import tempfile
+import zipfile
 
 import nanoid
 import py7zr

--- a/app/batid/services/source.py
+++ b/app/batid/services/source.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import tarfile
 import zipfile
+import tempfile
 
 import nanoid
 import py7zr
@@ -11,7 +12,7 @@ import requests
 
 
 class Source:
-    _dl_dir = os.environ.get("DOWNLOAD_DIR")
+    _dl_dir = tempfile.TemporaryDirectory(prefix="source_data_").name
 
     # Must be prefixed with a dot
 

--- a/app/batid/services/source.py
+++ b/app/batid/services/source.py
@@ -3,16 +3,23 @@ import gzip
 import os
 import shutil
 import tarfile
-import tempfile
 import zipfile
 
 import nanoid
 import py7zr
 import requests
+from app.settings import WRITABLE_DATA_DIR
+
+
+def source_data_directory() -> str:
+    directory_name = "source_data"
+    directory_path = os.path.join(WRITABLE_DATA_DIR, directory_name)
+    os.makedirs(directory_path, exist_ok=True)
+    return directory_path
 
 
 class Source:
-    _dl_dir = tempfile.TemporaryDirectory(prefix="source_data_").name
+    _dl_dir = source_data_directory()
 
     # Must be prefixed with a dot
 

--- a/app/batid/tests/data_fix/test_remove_light_buildings.py
+++ b/app/batid/tests/data_fix/test_remove_light_buildings.py
@@ -4,12 +4,14 @@ import shutil
 import geopandas as gpd
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
+from django.conf import settings
 
 from batid.models import Building
 from batid.models import DataFix
 from batid.services.data_fix.remove_light_buildings import buildings_to_remove
 from batid.services.data_fix.remove_light_buildings import remove_light_buildings
 from batid.services.data_fix.remove_light_buildings import save_results_as_file
+
 
 # we use TransactionTestCase beacause of the ThreadPoolExecutor use
 class TestRemoveLightBuildings(TransactionTestCase):
@@ -43,7 +45,9 @@ class TestRemoveLightBuildings(TransactionTestCase):
         self.assertEqual(len(buildings), 3)
 
         # create a folder to save the results
-        folder_name = "test_remove_light_buildings"
+        folder_name = os.path.join(
+            settings.WRITABLE_DATA_DIR, "test_remove_light_buildings"
+        )
 
         if os.path.exists(folder_name):
             shutil.rmtree(folder_name)

--- a/app/batid/tests/data_fix/test_remove_light_buildings.py
+++ b/app/batid/tests/data_fix/test_remove_light_buildings.py
@@ -2,9 +2,9 @@ import os
 import shutil
 
 import geopandas as gpd
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
-from django.conf import settings
 
 from batid.models import Building
 from batid.models import DataFix

--- a/common-services.yml
+++ b/common-services.yml
@@ -119,7 +119,6 @@ services:
         condition: service_healthy
 
   metabase:
-    cap_drop: ["ALL"]
     image: metabase/metabase
     container_name: metabase
 

--- a/common-services.yml
+++ b/common-services.yml
@@ -63,7 +63,7 @@ services:
       context: ./app
       dockerfile: ./Dockerfile
       target: app_worker
-    command: watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- celery -A app worker --loglevel=WARNING --concurrency=6 --uid 1000
+    command: watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- celery -A app worker --loglevel=WARNING --concurrency=6
     volumes:
       - ./app:/app
       - ./source_data:/data/downloads

--- a/common-services.yml
+++ b/common-services.yml
@@ -38,8 +38,6 @@ services:
     ports:
       - '127.0.0.1:8000:8000'
     command: python manage.py runserver 0.0.0.0:8000
-    volumes:
-      - ./app:/app
     depends_on:
       rabbitmq:
         condition: service_healthy

--- a/common-services.yml
+++ b/common-services.yml
@@ -17,6 +17,7 @@ services:
       - TRUST_DOWNSTREAM_PROXY=false
 
   nginx-letsencrypt:
+    cap_drop: ["ALL"]
     image: nginxproxy/acme-companion:2.5.0
     restart: unless-stopped
     volumes:
@@ -29,6 +30,7 @@ services:
       - nginx-proxy
 
   web:
+    cap_drop: ["ALL"]
     build:
       context: ./app
       dockerfile: ./Dockerfile
@@ -59,6 +61,7 @@ services:
       retries: 5
 
   worker:
+    cap_drop: ["ALL"]
     build:
       context: ./app
       dockerfile: ./Dockerfile
@@ -76,6 +79,7 @@ services:
     container_name: worker
 
   celery_beat:
+    cap_drop: ["ALL"]
     build:
       context: ./app
       dockerfile: ./Dockerfile
@@ -111,6 +115,7 @@ services:
       retries: 5
 
   flower:
+    cap_drop: ["ALL"]
     image: mher/flower
     container_name: flower
     command: celery flower --url_prefix=flower
@@ -121,6 +126,7 @@ services:
         condition: service_healthy
 
   metabase:
+    cap_drop: ["ALL"]
     image: metabase/metabase
     container_name: metabase
 

--- a/common-services.yml
+++ b/common-services.yml
@@ -67,9 +67,6 @@ services:
       dockerfile: ./Dockerfile
       target: app_worker
     command: watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- celery -A app worker --loglevel=WARNING --concurrency=6
-    volumes:
-      - ./app:/app
-      - ./source_data:/data/downloads
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -85,8 +82,6 @@ services:
       dockerfile: ./Dockerfile
       target: app_worker
     command: celery -A app beat --loglevel=WARNING
-    volumes:
-      - ./app:/app
     depends_on:
       rabbitmq:
         condition: service_healthy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,8 +26,6 @@ services:
       - ./.env.metabase.prod
       - ./.env.sentry.prod
     command: gunicorn app.wsgi:application --bind 0.0.0.0:8000 --threads 6 --workers 6
-    volumes:
-      - ./source_data:/home/app/source_data
     environment:
       - VIRTUAL_HOST=rnb-api.beta.gouv.fr
       - VIRTUAL_PORT=8000
@@ -39,8 +37,6 @@ services:
       file: common-services.yml
       service: worker
     command: celery -A app worker --concurrency=3 --loglevel=INFO
-    volumes:
-      - ./source_data:/home/app/source_data
     env_file:
       - ./.env.db_auth.prod
       - ./.env.app.prod

--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -25,8 +25,6 @@ services:
       - ./.env.rnb.sandbox
       - ./.env.sentry.sandbox
     command: gunicorn app.wsgi:application --bind 0.0.0.0:8000 --threads 6 --workers 6
-    volumes:
-      - ./source_data:/home/app/source_data
     environment:
       - VIRTUAL_HOST=sandbox.rnb-api.beta.gouv.fr
       - VIRTUAL_PORT=8000
@@ -38,8 +36,6 @@ services:
       file: common-services.yml
       service: worker
     command: celery -A app worker --concurrency=6 --loglevel=INFO
-    volumes:
-      - ./source_data:/home/app/source_data
     env_file:
       - ./.env.db_auth.sandbox
       - ./.env.app.sandbox

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -25,8 +25,6 @@ services:
       - ./.env.rnb.staging
       - ./.env.sentry.staging
     command: gunicorn app.wsgi:application --bind 0.0.0.0:8000 --threads 6 --workers 6
-    volumes:
-      - ./source_data:/home/app/source_data
     environment:
       - VIRTUAL_HOST=staging.rnb-api.beta.gouv.fr
       - VIRTUAL_PORT=8000
@@ -38,8 +36,6 @@ services:
       file: common-services.yml
       service: worker
     command: celery -A app worker --concurrency=6 --loglevel=INFO
-    volumes:
-      - ./source_data:/home/app/source_data
     env_file:
       - ./.env.db_auth.staging
       - ./.env.app.staging

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -21,7 +21,6 @@ services:
       - POSTGRES_PASSWORD=postgres
       - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq//
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
-      - DOWNLOAD_DIR=/data/downloads
       - MIN_BDG_AREA=5
       - WAIT_HOSTS=db:5432 rabbitmq:5672 redis:6379
       - WAIT_BEFORE=8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - '8888:8888' # Jupyter notebook
       - '5678:5678'
     command: python -m debugpy --listen 0.0.0.0:5678 manage.py runserver 0.0.0.0:8000
+    volumes:
+      - ./app:/app
     env_file:
       - ./.env.db_auth.dev
       - ./.env.app.dev
@@ -65,6 +67,8 @@ services:
     extends:
       file: common-services.yml
       service: worker
+    volumes:
+      - ./app:/app
     env_file:
       - ./.env.db_auth.dev
       - ./.env.app.dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
       - '8888:8888' # Jupyter notebook
       - '5678:5678'
     command: python -m debugpy --listen 0.0.0.0:5678 manage.py runserver 0.0.0.0:8000
-    volumes:
-      - ./source_data:/data/downloads
     env_file:
       - ./.env.db_auth.dev
       - ./.env.app.dev

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,3 +1,3 @@
-FROM jwilder/nginx-proxy:1.8.0
+FROM nginxproxy/nginx-proxy:1.8
 COPY vhost.d/default /etc/nginx/vhost.d/default
 COPY custom.conf /etc/nginx/conf.d/custom.conf


### PR DESCRIPTION
- Rajout d'un `cap_drop` explicite sur les containers de l'app
- Utiliser un utilisateur non-root pour `web` et `worker`
- Changement applicatif pour simplifier cela : utiliser un répertoire temporaire plutôt qu'un mounted volume
- ~J'ai split cette tâche à part pour Nginx : c'est plus compliqué et à voir si on souhaite garder ça v.s. un LB devant~
- EDIT: Vu avec @am-beta, le worker process en lui même n'est pas root, donc il semble overkill de changer le user de nginx-proxy pour le moment