### PR TITLE
Fix du docker build

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -13,7 +13,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     POETRY_VIRTUALENVS_PATH="/python_venv" \
     PATH="/root/.local/bin:${PATH}"
 
-RUN pipx install poetry==${POETRY_VERSION}
+RUN pipx install --python=python3 poetry==${POETRY_VERSION}
 
 COPY pyproject.toml poetry.lock ./
 RUN poetry env use $(which python3)


### PR DESCRIPTION
De ce que j'ai compris :
- Lorsque pipx installe poetry il utilise par défaut une certaine version de Python.
- pour savoir laquelle, on peut faire `pipx install --help` et on obtient (entre autre) `The default python executable used to install a package is /usr/bin/python3`
- On peut donc faire `/usr/bin/python3 --version` et on voit que pipx utilise par défaut Python3.11
```
#12 [worker base  5/12] RUN /usr/bin/python3 --version
#12 0.146 Python 3.11.2
```
- poetry se retrouve alors installé dans un environnement en Python 3.11 qui n'est pas compatible avec les requirements listés dans pyproject.toml
- Je peux vérifier vers quelle version pointe la commande `python3` :
```
#11 [worker base  4/11] RUN which python3
#11 0.205 /usr/local/bin/python3
#11 DONE 0.2s

#12 [web base  5/11] RUN python3 --version
#12 0.217 Python 3.13.4
#12 DONE 0.2s
```
- elle pointe bien vers python 3.14, donc je peux forcer pipx à utiliser cette version là. `RUN pipx install --python=python3 poetry==${POETRY_VERSION}` 
- poetry est installé avec la même version de python que celle qui est spécifiée dans pyproject, il est content.