### PR TITLE
Updater un batiment sans le modifier ne fait rien

### DIFF
--- a/app/batid/models/building.py
+++ b/app/batid/models/building.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from copy import deepcopy
 from typing import Optional
 
 from django.contrib.auth.models import User
@@ -197,13 +198,13 @@ class Building(BuildingAbstract):
         shape: GEOSGeometry | None = None,
     ):
         if (
-            status is None
-            and addresses_id is None
-            and ext_ids is None
-            and shape is None
+            (status is None or status == self.status)
+            and (addresses_id is None or addresses_id == self.addresses_id)
+            and (ext_ids is None or ext_ids == self.ext_ids)
+            and (shape is None or shape == self.shape)
         ):
-
-            raise Exception("Missing data to update the building")
+            # let's do nothing
+            return
 
         if not self.is_active:
             raise OperationOnInactiveBuilding(
@@ -283,6 +284,10 @@ class Building(BuildingAbstract):
 
         if not existing_ext_ids:
             existing_ext_ids = []
+
+        # we don't want to directly modify existing_ext_ids
+        # in case it is a reference to the object ext_ids
+        existing_ext_ids = deepcopy(existing_ext_ids)
 
         existing_ext_ids.append(ext_id)
         new_ext_ids = sorted(existing_ext_ids, key=lambda k: k["created_at"])

--- a/app/batid/tests/test_models.py
+++ b/app/batid/tests/test_models.py
@@ -406,6 +406,29 @@ class TestUpdateBuilding(TestCase):
         print(f"New updated_at: {b.updated_at}")
         self.assertNotEqual(b.updated_at, old_updated_at)
 
+    def test_update_building_without_changing_something_does_nothing(self):
+        b = Building.objects.get(rnb_id=self.rnb_id)
+        status = b.status
+        shape = b.shape
+        ext_ids = b.ext_ids
+        addresses_id = b.addresses_id
+
+        sys_period = b.sys_period
+
+        b.update(
+            self.user, event_origin={"source": "xxx"}, status=status, addresses_id=None
+        )
+        b.update(
+            self.user,
+            event_origin={"source": "xxx"},
+            status=status,
+            addresses_id=addresses_id,
+            shape=shape,
+            ext_ids=ext_ids,
+        )
+        b.refresh_from_db()
+        self.assertEqual(b.sys_period, sys_period)
+
 
 class TestExtIdsComparison(TestCase):
     def test_ext_ids_equal(self):


### PR DESCRIPTION
Pour éviter d'avoir des modifs fantômes.

Au passage ça m'a permis de trouver un petit bug dans une fonction qui modifiait des arguments qu'on lui passe en référence sans vraiment le dire.