### PR TITLE
Autoriser les urls publiques de questions metabase

### DIFF
--- a/app/batid/views.py
+++ b/app/batid/views.py
@@ -96,6 +96,7 @@ class MetabaseProxyView(UserPassesTestMixin, ProxyView):
     add_x_forwarded = True
     allowed_urls = [
         "/metabase/public/dashboard/",  # HTML pages of public dashboards
+        "/metabase/public/question/",  # HTML pages of public questions
         "/metabase/app/",  # Static resources of metabase (JS scripts)
         "/metabase/api/session/properties",  # App properties
         "/metabase/api/public/",  # Public APIs


### PR DESCRIPTION
Pour mettre à jour notre page stats, j'aimerais mettre directement des questions metabase.