### PR TITLE
Eviter la mise-à-jour de `notebook`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
     directory: "/app"
     schedule: { interval: "monthly" }
     target-branch: "main"
+    ignore:
+      - dependency-name: "notebook"
     groups:
       production:
         dependency-type: 'production'


### PR DESCRIPTION
Pour éviter le retour de https://www.notion.so/referentielnationaldesbatiments/Notebooks-ne-marchent-plus-4952ea3eebcb471ba4b55e57d7a2a9cf

Idéalement il faudra passer à la prochaine version, mais c'est une dépendance dev-only chargée optionnellement, donc moins urgent que d'éviter de passer du temps à chaque fois IMO