### PR TITLE
Rest_framework_tracking : ne pas logger le corps des réponses

### DIFF
--- a/app/api_alpha/tests/test_log.py
+++ b/app/api_alpha/tests/test_log.py
@@ -41,9 +41,12 @@ class LogEndpointsTest(APITestCase):
 
         self.assertEqual(r.status_code, 200)
 
-        count = APIRequestLog.objects.all().count()
+        logs = APIRequestLog.objects.all()
+        self.assertEqual(len(logs), 1)
 
-        self.assertEqual(count, 1)
+        log = logs[0]
+        # assert the response is not logged
+        self.assertEqual(log.response, None)
 
     @mock.patch.object(ListBuildingQuerySerializer, "validate", lambda self, data: data)
     def test_list_no_log(self):

--- a/app/api_alpha/utils/logging_mixin.py
+++ b/app/api_alpha/utils/logging_mixin.py
@@ -1,4 +1,5 @@
 from rest_framework_tracking.mixins import LoggingMixin
+from rest_framework_tracking.models import APIRequestLog
 
 
 class RNBLoggingMixin(LoggingMixin):
@@ -7,3 +8,9 @@ class RNBLoggingMixin(LoggingMixin):
 
     def should_log(self, request, response):
         return request.query_params.get("from") != "monitoring"
+
+    def handle_log(self):
+        data = self.log
+        # API responses take too much DB space and are not useful
+        data["response"] = None
+        APIRequestLog(**data).save()


### PR DESCRIPTION
On n'utilise pas le `response` des requêtes API qui sont logguées par Rest_framework_tracking, or cela prend beaucoup de place. On a aussi des erreurs côté Sentry quand la réponse est trop grande (j'ai l'impression).

Cette PR loggue toujours l'activité de notre API, mais plus le corps des réponses.