### PR TITLE
Fix user agent trop long

### DIFF
--- a/app/api_alpha/tests/test_log.py
+++ b/app/api_alpha/tests/test_log.py
@@ -49,6 +49,20 @@ class LogEndpointsTest(APITestCase):
         self.assertEqual(log.response, None)
 
     @mock.patch.object(ListBuildingQuerySerializer, "validate", lambda self, data: data)
+    def test_log_big_user_agent(self):
+        user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/22G100 [FBAN/FBIOS;FBAV/540.0.0.44.68;FBBV/828638047;FBDV/iPhone12,3;FBMD/iPhone;FBSN/iOS;FBSV/18.6.2;FBSS/3;FBID/phone;FBLC/fr_FR;FBOP/5;FBRV/834137514;IABMV/1]"
+        r = self.client.get("/api/alpha/buildings/", HTTP_USER_AGENT=user_agent)
+
+        self.assertEqual(r.status_code, 200)
+
+        logs = APIRequestLog.objects.all()
+        self.assertEqual(len(logs), 1)
+        log = logs[0]
+
+        # assert the user agent is truncated
+        self.assertEqual(log.user_agent, user_agent[:255])
+
+    @mock.patch.object(ListBuildingQuerySerializer, "validate", lambda self, data: data)
     def test_list_no_log(self):
         r = self.client.get("/api/alpha/buildings/?from=monitoring")
 

--- a/app/api_alpha/utils/logging_mixin.py
+++ b/app/api_alpha/utils/logging_mixin.py
@@ -13,4 +13,8 @@ class RNBLoggingMixin(LoggingMixin):
         data = self.log
         # API responses take too much DB space and are not useful
         data["response"] = None
+
+        # truncate user agent at 255 chars because of DB limit
+        data["user_agent"] = data["user_agent"][:255]
+
         APIRequestLog(**data).save()


### PR DESCRIPTION
https://sentry.incubateur.net/organizations/betagouv/issues/222439/?project=148&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream

Le user agent en base est limité à 255 chars.