### PR TITLE
Réduction de l'utilisation Sentry

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -304,7 +304,7 @@ if sentry_dsn:
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.
         # We recommend adjusting this value in production.
-        traces_sample_rate=1.0,
+        traces_sample_rate=0.01,
         # If you wish to associate users to errors (assuming you are using
         # django.contrib.auth) you may enable sending PII data.
         send_default_pii=True,


### PR DESCRIPTION
Je pense que ce 100% était arrivé là par inadvertance.

https://docs.sentry.io/platforms/python/sampling/#configuring-the-transaction-sample-rate