### PR TITLE
Gestion des bâtiments points dans calcul de déplacement d'une shape

### DIFF
--- a/app/batid/tests/test_models.py
+++ b/app/batid/tests/test_models.py
@@ -14,9 +14,9 @@ from batid.models import Address
 from batid.models import Building
 from batid.models import Contribution
 from batid.tests.factories.users import ContributorUserFactory
-from batid.utils.misc import ext_ids_equal
 from batid.tests.helpers import coords_to_mp_geom
-from batid.exceptions import BuildingCannotMove
+from batid.utils.misc import ext_ids_equal
+
 
 class TestBuilding(TestCase):
     def test_merge_buildings(self):
@@ -529,32 +529,16 @@ class TestUpdateBuilding(TestCase):
             status="constructed",
         )
 
-        new_mp = coords_to_mp_geom([
+        new_mp = coords_to_mp_geom(
             [
-              3.08623598495754,
-              45.61185838134952
-            ],
-            [
-              3.086189953169196,
-              45.61179511124274
-            ],
-            [
-              3.0863369318603304,
-              45.611765170898906
-            ],
-            [
-              3.086351468214332,
-              45.61189566548654
-            ],
-            [
-              3.0862561743377626,
-              45.61191769701006
-            ],
-            [
-              3.08623598495754,
-              45.61185838134952
+                [3.08623598495754, 45.61185838134952],
+                [3.086189953169196, 45.61179511124274],
+                [3.0863369318603304, 45.611765170898906],
+                [3.086351468214332, 45.61189566548654],
+                [3.0862561743377626, 45.61191769701006],
+                [3.08623598495754, 45.61185838134952],
             ]
-          ])
+        )
 
         with self.assertRaises(BuildingCannotMove):
             point_bdg.update(
@@ -563,7 +547,7 @@ class TestUpdateBuilding(TestCase):
                 shape=new_mp,
                 status=None,
                 addresses_id=None,
-        )
+            )
 
 
 class TestExtIdsComparison(TestCase):

--- a/app/batid/utils/geo.py
+++ b/app/batid/utils/geo.py
@@ -184,7 +184,7 @@ def assert_new_shape_is_close_enough(
     # Using shapely to calculate nearest points
     shapely_old_geom = wkt.loads(old_geom.wkt)
     shapely_new_geom = wkt.loads(new_geom.wkt)
-    old_pos, new_pos = nearest_points(shapely_old_geom, shapely_new_geom)   
+    old_pos, new_pos = nearest_points(shapely_old_geom, shapely_new_geom)
 
     geod = Geod(ellps="WGS84")
 


### PR DESCRIPTION
Pendant l'import de la BD Topo, on a tenté de mettre à jour la shape d'un bâtiment point. La nouvelle shape était un long rectangle (un quai de gare). La vérification `assert_new_shape_is_close_enough()`a raise un exception car l'ancien point était trop loin du centroïde du nouveau polygone.

On change la méthode de calcul de distance entre ancienne et nouvelle shape lors de la mise à jour d'un bâtiment.