### PR TITLE
Exclure les URLs de metabase du rate limiting Nginx

### DIFF
--- a/nginx/custom.conf
+++ b/nginx/custom.conf
@@ -4,6 +4,7 @@ client_max_body_size 10M;
 # Because we can have a lot of legitimate concurrent requests to the tiles endpoint
 map $request_uri $api_rate_limit_key {
     ~*/tiles/* "";
+    ~*/metabase/* "";
     default $binary_remote_addr;
 }
 


### PR DESCRIPTION
pour éviter les 429 intempestives.