### PR TITLE
pause bal import in schedule

### DIFF
--- a/app/app/schedule.py
+++ b/app/app/schedule.py
@@ -56,11 +56,11 @@ production_schedule = {
         "task": "batid.tasks.queue_full_ban_import",
         "schedule": crontab(minute=0, hour=0, day_of_month="1,15"),
     },
-    "create_bal_links": {
-        "task": "batid.tasks.queue_full_bal_rnb_links",
-        # we create links after the BAN has been imported
-        "schedule": crontab(minute=0, hour=0, day_of_month="2,16"),
-    },
+    # "create_bal_links": {
+    #     "task": "batid.tasks.queue_full_bal_rnb_links",
+    #     # we create links after the BAN has been imported
+    #     "schedule": crontab(minute=0, hour=0, day_of_month="2,16"),
+    # },
     "send_monthly_leaderboard_emails": {
         "task": "batid.tasks.send_monthly_leaderboard_emails",
         # 1st of each month at 6am UTC


### PR DESCRIPTION
L'import de la BAL est cassé à cause des  identifiants BAN en doublons. Il me semble que cela fait crasher les machines.