### PR TITLE
On ne marque plus, on valide

### DIFF
--- a/app/api_alpha/endpoints/buildings/list_create_buildings.py
+++ b/app/api_alpha/endpoints/buildings/list_create_buildings.py
@@ -255,7 +255,7 @@ class ListCreateBuildings(RNBLoggingMixin, APIView):
                                         "description": "Géométrie du bâtiment au format WKT ou HEX, en WGS84. La géométrie attendue est idéalement un polygone représentant le bâtiment, mais il est également possible de ne donner qu'un point.",
                                         "example": "POLYGON((2.3522 48.8566, 2.3532 48.8567, 2.3528 48.857, 2.3522 48.8566))",
                                     },
-                                    "mark_as_correct": {
+                                    "is_valid": {
                                         "type": "boolean",
                                         "default": False,
                                         "description": "Optionnel. Si `True`, le bâtiment est marqué comme correct dès sa création. L'utilisateur déclare ainsi que l'ensemble des informations liées aux bâtiments (statut, adresse, géométrie) sont correctes. Vaut 'False' par défaut, ce qui revient à simplement créer le bâtiment sans le marquer comme correct.",
@@ -332,7 +332,7 @@ class ListCreateBuildings(RNBLoggingMixin, APIView):
                     addresses_id=addresses_id,
                     shape=shape,
                     ext_ids=[],
-                    mark_as_correct=data.get("mark_as_correct", False),
+                    is_valid=data.get("is_valid", False),
                 )
             except BANAPIDown:
                 raise ServiceUnavailable(detail="BAN API is currently down")

--- a/app/api_alpha/endpoints/buildings/single_building.py
+++ b/app/api_alpha/endpoints/buildings/single_building.py
@@ -284,7 +284,7 @@ Permet à l'utilisateur de valider l'état actuel du bâtiment (`True`) ou de re
                         status,
                         addresses_id,
                         shape=shape,
-                        validate=data.get("validate"),
+                        validate=data.get("is_valid"),
                     )
             except BANAPIDown:
                 raise ServiceUnavailable(detail="BAN API is currently down")

--- a/app/api_alpha/endpoints/buildings/single_building.py
+++ b/app/api_alpha/endpoints/buildings/single_building.py
@@ -129,10 +129,10 @@ Cet endpoint permet de :
   RNB. Par exemple un arbre qui aurait été par erreur répertorié comme un
   bâtiment du RNB.
 * réactiver un ID-RNB, si celui-ci a été désactivé par erreur.
-* marquer un bâtiment comme correct.
+* valider un bâtiment.
 
 Il n'est pas possible de simultanément mettre à jour un bâtiment et de le désactiver/réactiver.
-Il n'est pas possible de simultanément marquer un bâtiment comme correct et de le désactiver/réactiver.
+Il n'est pas possible de simultanément valider un bâtiment et de le désactiver/réactiver.
 
 Cet endpoint nécessite d'être identifié et d'avoir des droits d'édition du RNB.
 
@@ -141,7 +141,7 @@ Exemples valides:
 * ```{"comment": "RNB ID désactivé par erreur, on le réactive", "is_active": True}```
 * ```{"comment": "bâtiment démoli", "status": "demolished"}```
 * ```{"comment": "bâtiment en ruine", "status": "notUsable", "addresses_cle_interop": ["75105_8884_00004"]}```
-* ```{"comment": "je marque que ce bâtiment est correct", "mark_as_correct": True}```
+* ```{"comment": "je valide ce bâtiment", "validate": True}```
 """),
                 "operationId": "patchBuilding",
                 "parameters": [
@@ -201,14 +201,14 @@ Si ce paramêtre est :
                                         "type": "string",
                                         "description": """Géométrie du bâtiment au format WKT ou HEX, en WGS84. La géometrie attendue est idéalement un polygone représentant le bâtiment, mais il est également possible de ne donner qu'un point.""",
                                     },
-                                    "mark_as_correct": {
+                                    "validate": {
                                         "type": "boolean",
                                         "description": LiteralStr(
                                             """\
-Permet à l'utilisateur de marquer que l'état actuel du bâtiment est correct (`True`) ou de retirer cette indication s'il l'avait précédemment marquée (`False`).
+Permet à l'utilisateur de valider l'état actuel du bâtiment (`True`) ou de retirer cette validation s'il l'avait précédemment posée (`False`).
 
 * Peut être envoyé seul ou en complément d'une modification (`status`, `addresses_cle_interop`, `shape`).
-* Lorsqu'un bâtiment est modifié, la liste des utilisateurs l'ayant marqué comme correct est réinitialisée."""
+* Lorsqu'un bâtiment est modifié, la liste des utilisateurs l'ayant validé est réinitialisée."""
                                         ),
                                     },
                                 },
@@ -284,7 +284,7 @@ Permet à l'utilisateur de marquer que l'état actuel du bâtiment est correct (
                         status,
                         addresses_id,
                         shape=shape,
-                        mark_as_correct=data.get("mark_as_correct"),
+                        validate=data.get("validate"),
                     )
             except BANAPIDown:
                 raise ServiceUnavailable(detail="BAN API is currently down")

--- a/app/api_alpha/serializers/building_history.py
+++ b/app/api_alpha/serializers/building_history.py
@@ -22,8 +22,8 @@ class PlainAddressSerializer(serializers.Serializer):
 
 class PlainPublicUserSerializer(serializers.Serializer):
     """
-    Serializer for an entry of the marked_as_correct_by list returned by the history endpoint.
-    Each entry describes a user who has marked the building version as correct.
+    Serializer for an entry of the validated_by list returned by the history endpoint.
+    Each entry describes a user who has validated the building version.
     The fields must be a copy of the PublicUserSerializer fields.
     """
 
@@ -72,11 +72,11 @@ class BuildingEventSerializer(serializers.Serializer):
             if set(prev_addresses) != set(curr_addresses):
                 updated_fields.append("addresses")
 
-            prev_marked = previous.get("marked_as_correct_by") or []
-            curr_marked = current.get("marked_as_correct_by") or []
+            prev_validated = previous.get("validated_by") or []
+            curr_validated = current.get("validated_by") or []
 
-            if set(prev_marked) != set(curr_marked):
-                updated_fields.append("marked_as_correct_by")
+            if set(prev_validated) != set(curr_validated):
+                updated_fields.append("validated_by")
 
             instance_copy["details"]["updated_fields"] = updated_fields
 
@@ -112,4 +112,4 @@ class BuildingHistorySerializer(serializers.Serializer):
     ext_ids = ExtIdSerializer(many=True)
     updated_at = serializers.DateTimeField()
     addresses = PlainAddressSerializer(many=True, read_only=True)
-    marked_as_correct_by = PlainPublicUserSerializer(many=True, read_only=True)
+    validated_by = PlainPublicUserSerializer(many=True, read_only=True)

--- a/app/api_alpha/serializers/serializers.py
+++ b/app/api_alpha/serializers/serializers.py
@@ -447,7 +447,7 @@ class BuildingCreateSerializerCore(serializers.Serializer):
 
 class BuildingCreateSerializer(BuildingCreateSerializerCore):
     comment = serializers.CharField(required=False, allow_blank=True)
-    mark_as_correct = serializers.BooleanField(required=False, default=False)
+    is_valid = serializers.BooleanField(required=False, default=False)
 
 
 class BuildingMergeSerializer(serializers.Serializer):

--- a/app/api_alpha/serializers/serializers.py
+++ b/app/api_alpha/serializers/serializers.py
@@ -109,8 +109,8 @@ class BuildingSerializer(serializers.ModelSerializer):
         many=True, read_only=True, source="addresses_read_only"
     )
 
-    marked_as_correct_by = PublicUserSerializer(
-        many=True, read_only=True, source="marked_as_correct_read_only"
+    validated_by = PublicUserSerializer(
+        many=True, read_only=True, source="validated_by_read_only"
     )
 
     ext_ids = ExtIdSerializer(many=True, read_only=True)
@@ -127,7 +127,7 @@ class BuildingSerializer(serializers.ModelSerializer):
             "ext_ids",
             "is_active",
             "plots",
-            "marked_as_correct_by",
+            "validated_by",
         ]
 
 
@@ -230,7 +230,7 @@ class BuildingGeoJSONSerializer(BuildingSerializer, GeoFeatureModelSerializer):
             "addresses",
             "is_active",
             "plots",
-            "marked_as_correct_by",
+            "validated_by",
         )
         geo_field = "shape"
         id_field = "rnb_id"
@@ -264,8 +264,8 @@ class BuildingClosestSerializer(serializers.ModelSerializer):
     addresses = AddressSerializer(
         many=True, read_only=True, source="addresses_read_only"
     )
-    marked_as_correct_by = PublicUserSerializer(
-        many=True, read_only=True, source="marked_as_correct_read_only"
+    validated_by = PublicUserSerializer(
+        many=True, read_only=True, source="validated_by_read_only"
     )
 
     def get_distance(self, obj):
@@ -281,7 +281,7 @@ class BuildingClosestSerializer(serializers.ModelSerializer):
             "addresses",
             "ext_ids",
             "shape",
-            "marked_as_correct_by",
+            "validated_by",
         ]
 
 
@@ -406,7 +406,7 @@ class BuildingUpdateSerializer(serializers.Serializer):
         required=False,
     )
     shape = serializers.CharField(required=False, validators=[shape_is_valid])
-    mark_as_correct = serializers.BooleanField(required=False)
+    validate = serializers.BooleanField(required=False)
     comment = serializers.CharField(required=False, allow_blank=True)
 
     def validate(self, data):
@@ -414,17 +414,17 @@ class BuildingUpdateSerializer(serializers.Serializer):
             data.get("status") is not None
             or data.get("addresses_cle_interop") is not None
             or data.get("shape") is not None
-            or data.get("mark_as_correct") is not None
+            or data.get("validate") is not None
         ):
             raise serializers.ValidationError(
-                "Vous devez définir soit 'is_active' soit 'status'/'addresses_cle_interop'/'shape'/'mark_as_correct', pas les deux en même temps"
+                "Vous devez définir soit 'is_active' soit 'status'/'addresses_cle_interop'/'shape'/'validate', pas les deux en même temps"
             )
         if (
             data.get("is_active") is None
             and data.get("status") is None
             and data.get("addresses_cle_interop") is None
             and data.get("shape") is None
-            and data.get("mark_as_correct") is None
+            and data.get("validate") is None
         ):
             raise serializers.ValidationError(
                 "Arguments vides dans le corps de la requête"

--- a/app/api_alpha/serializers/serializers.py
+++ b/app/api_alpha/serializers/serializers.py
@@ -406,7 +406,7 @@ class BuildingUpdateSerializer(serializers.Serializer):
         required=False,
     )
     shape = serializers.CharField(required=False, validators=[shape_is_valid])
-    validate = serializers.BooleanField(required=False)
+    is_valid = serializers.BooleanField(required=False)
     comment = serializers.CharField(required=False, allow_blank=True)
 
     def validate(self, data):
@@ -414,17 +414,17 @@ class BuildingUpdateSerializer(serializers.Serializer):
             data.get("status") is not None
             or data.get("addresses_cle_interop") is not None
             or data.get("shape") is not None
-            or data.get("validate") is not None
+            or data.get("is_valid") is not None
         ):
             raise serializers.ValidationError(
-                "Vous devez définir soit 'is_active' soit 'status'/'addresses_cle_interop'/'shape'/'validate', pas les deux en même temps"
+                "Vous devez définir soit 'is_active' soit 'status'/'addresses_cle_interop'/'shape'/'is_valid', pas les deux en même temps"
             )
         if (
             data.get("is_active") is None
             and data.get("status") is None
             and data.get("addresses_cle_interop") is None
             and data.get("shape") is None
-            and data.get("validate") is None
+            and data.get("is_valid") is None
         ):
             raise serializers.ValidationError(
                 "Arguments vides dans le corps de la requête"

--- a/app/api_alpha/serializers/serializers.py
+++ b/app/api_alpha/serializers/serializers.py
@@ -455,7 +455,15 @@ class BuildingCreateSerializerCore(serializers.Serializer):
 
 class BuildingCreateSerializer(BuildingCreateSerializerCore):
     comment = serializers.CharField(required=False, allow_blank=True)
-    is_valid = serializers.BooleanField(required=False, default=False)
+
+    def get_fields(self):
+        fields = super().get_fields()
+        # Champ exposé sous "is_valid" côté API, mappé sur "validation" en interne
+        # (évite le clash avec la méthode Serializer.is_valid()).
+        fields["is_valid"] = serializers.BooleanField(
+            required=False, default=False, source="validation"
+        )
+        return fields
 
 
 class BuildingMergeSerializer(serializers.Serializer):

--- a/app/api_alpha/serializers/serializers.py
+++ b/app/api_alpha/serializers/serializers.py
@@ -406,15 +406,23 @@ class BuildingUpdateSerializer(serializers.Serializer):
         required=False,
     )
     shape = serializers.CharField(required=False, validators=[shape_is_valid])
-    is_valid = serializers.BooleanField(required=False)  # type: ignore[assignment]
     comment = serializers.CharField(required=False, allow_blank=True)
+
+    def get_fields(self):
+        fields = super().get_fields()
+        # Public API field "is_valid" is mapped to "validation" internally
+        # to avoid naming collision with DRF internals
+        fields["is_valid"] = serializers.BooleanField(
+            required=False, source="validation"
+        )
+        return fields
 
     def validate(self, data):
         if data.get("is_active") is not None and (
             data.get("status") is not None
             or data.get("addresses_cle_interop") is not None
             or data.get("shape") is not None
-            or data.get("is_valid") is not None
+            or data.get("validation") is not None
         ):
             raise serializers.ValidationError(
                 "Vous devez définir soit 'is_active' soit 'status'/'addresses_cle_interop'/'shape'/'is_valid', pas les deux en même temps"
@@ -424,7 +432,7 @@ class BuildingUpdateSerializer(serializers.Serializer):
             and data.get("status") is None
             and data.get("addresses_cle_interop") is None
             and data.get("shape") is None
-            and data.get("is_valid") is None
+            and data.get("validation") is None
         ):
             raise serializers.ValidationError(
                 "Arguments vides dans le corps de la requête"

--- a/app/api_alpha/serializers/serializers.py
+++ b/app/api_alpha/serializers/serializers.py
@@ -406,7 +406,7 @@ class BuildingUpdateSerializer(serializers.Serializer):
         required=False,
     )
     shape = serializers.CharField(required=False, validators=[shape_is_valid])
-    is_valid = serializers.BooleanField(required=False)
+    is_valid = serializers.BooleanField(required=False)  # type: ignore[assignment]
     comment = serializers.CharField(required=False, allow_blank=True)
 
     def validate(self, data):

--- a/app/api_alpha/tests/buildings/test_creation.py
+++ b/app/api_alpha/tests/buildings/test_creation.py
@@ -267,8 +267,8 @@ class BuildingPostTest(APITestCase):
 
 
 @override_settings(MAX_BUILDING_AREA=float("inf"))
-class BuildingPostMarkAsCorrectTest(APITestCase):
-    """Tests for the `mark_as_correct` parameter on POST /api/alpha/buildings/."""
+class BuildingPostIsValidTest(APITestCase):
+    """Tests for the `is_valid` parameter on POST /api/alpha/buildings/."""
 
     def setUp(self):
         self.user = ContributorUserFactory(
@@ -291,36 +291,36 @@ class BuildingPostMarkAsCorrectTest(APITestCase):
             content_type="application/json",
         )
 
-    def test_create_with_mark_as_correct_true(self):
+    def test_create_with_is_valid_true(self):
         """
-        Input: POST creating a building with `mark_as_correct=True`.
+        Input: POST creating a building with `is_valid=True`.
         Expected: 201; the created building has the requesting user's id in
-        marked_as_correct_by.
+        validated_by.
         """
-        r = self._post({**self.data, "mark_as_correct": True})
+        r = self._post({**self.data, "is_valid": True})
 
         self.assertEqual(r.status_code, 201)
         building = Building.objects.get(rnb_id=r.json()["rnb_id"])
-        self.assertEqual(building.marked_as_correct_by, [self.user.id])
+        self.assertEqual(building.validated_by, [self.user.id])
 
-    def test_create_with_mark_as_correct_false(self):
+    def test_create_with_is_valid_false(self):
         """
-        Input: POST creating a building with `mark_as_correct=False`.
-        Expected: 201; the created building has an empty marked_as_correct_by.
+        Input: POST creating a building with `is_valid=False`.
+        Expected: 201; the created building has an empty validated_by.
         """
-        r = self._post({**self.data, "mark_as_correct": False})
+        r = self._post({**self.data, "is_valid": False})
 
         self.assertEqual(r.status_code, 201)
         building = Building.objects.get(rnb_id=r.json()["rnb_id"])
-        self.assertEqual(building.marked_as_correct_by, [])
+        self.assertEqual(building.validated_by, [])
 
-    def test_create_without_mark_as_correct(self):
+    def test_create_without_is_valid(self):
         """
-        Input: POST creating a building without the `mark_as_correct` field.
-        Expected: 201; marked_as_correct_by defaults to an empty list.
+        Input: POST creating a building without the `is_valid` field.
+        Expected: 201; validated_by defaults to an empty list.
         """
         r = self._post(self.data)
 
         self.assertEqual(r.status_code, 201)
         building = Building.objects.get(rnb_id=r.json()["rnb_id"])
-        self.assertEqual(building.marked_as_correct_by, [])
+        self.assertEqual(building.validated_by, [])

--- a/app/api_alpha/tests/buildings/test_listing.py
+++ b/app/api_alpha/tests/buildings/test_listing.py
@@ -75,8 +75,8 @@ class BuildingsEndpointsTest(APITestCase):
                 [5.721187072129851, 45.18439363812283],
             ],
         )
-        bdg.marked_as_correct_by = [self.user.id]
-        bdg.save(update_fields=["marked_as_correct_by"])
+        bdg.validated_by = [self.user.id]
+        bdg.save(update_fields=["validated_by"])
 
     def test_bdg_in_bbox(self):
 
@@ -115,7 +115,7 @@ class BuildingsEndpointsTest(APITestCase):
                     },
                     "rnb_id": "INGRENOBLEGO",
                     "is_active": True,
-                    "marked_as_correct_by": [
+                    "validated_by": [
                         {
                             "display_name": "user",
                             "id": self.user.id,
@@ -194,7 +194,7 @@ class BuildingsEndpointsTest(APITestCase):
                     },
                     "rnb_id": "INGRENOBLEGO",
                     "is_active": True,
-                    "marked_as_correct_by": [
+                    "validated_by": [
                         {
                             "display_name": "user",
                             "id": self.user.id,
@@ -273,7 +273,7 @@ class BuildingsEndpointsTest(APITestCase):
                     },
                     "rnb_id": "INGRENOBLEGO",
                     "is_active": True,
-                    "marked_as_correct_by": [
+                    "validated_by": [
                         {
                             "display_name": "user",
                             "id": self.user.id,
@@ -344,7 +344,7 @@ class BuildingsEndpointsTest(APITestCase):
                     "shape": None,
                     "rnb_id": "XXX",
                     "is_active": True,
-                    "marked_as_correct_by": [],
+                    "validated_by": [],
                 }
             ],
         }
@@ -394,7 +394,7 @@ class BuildingsEndpointsTest(APITestCase):
                     },
                     "addresses": [],
                     "is_active": True,
-                    "marked_as_correct_by": [],
+                    "validated_by": [],
                 },
                 {
                     "addresses": [],
@@ -422,7 +422,7 @@ class BuildingsEndpointsTest(APITestCase):
                     },
                     "rnb_id": "INGRENOBLEGO",
                     "is_active": True,
-                    "marked_as_correct_by": [
+                    "validated_by": [
                         {
                             "display_name": "user",
                             "id": self.user.id,
@@ -474,7 +474,7 @@ class BuildingsEndpointsTest(APITestCase):
                         "ext_ids": None,
                         "addresses": [],
                         "is_active": True,
-                        "marked_as_correct_by": [],
+                        "validated_by": [],
                     },
                 },
                 {
@@ -501,7 +501,7 @@ class BuildingsEndpointsTest(APITestCase):
                         "ext_ids": None,
                         "addresses": [],
                         "is_active": True,
-                        "marked_as_correct_by": [
+                        "validated_by": [
                             {
                                 "display_name": "user",
                                 "id": self.user.id,
@@ -555,7 +555,7 @@ class BuildingsEndpointsTest(APITestCase):
             },
             "addresses": [],
             "is_active": True,
-            "marked_as_correct_by": [],
+            "validated_by": [],
         }
 
         self.assertEqual(r.json(), expected)
@@ -642,7 +642,7 @@ class BuildingsEndpointsWithAuthTest(BuildingsEndpointsTest):
                     },
                     "addresses": [],
                     "is_active": True,
-                    "marked_as_correct_by": [],
+                    "validated_by": [],
                 },
                 {
                     "ext_ids": None,
@@ -668,7 +668,7 @@ class BuildingsEndpointsWithAuthTest(BuildingsEndpointsTest):
                     },
                     "addresses": [],
                     "is_active": True,
-                    "marked_as_correct_by": [],
+                    "validated_by": [],
                 },
                 {
                     "addresses": [],
@@ -696,7 +696,7 @@ class BuildingsEndpointsWithAuthTest(BuildingsEndpointsTest):
                     },
                     "rnb_id": "INGRENOBLEGO",
                     "is_active": True,
-                    "marked_as_correct_by": [
+                    "validated_by": [
                         {
                             "display_name": "user",
                             "id": self.user.id,
@@ -855,7 +855,7 @@ class BuildingsWithPlots(APITestCase):
                         {"id": "one", "bdg_cover_ratio": 0.529665644404105},
                         {"id": "two", "bdg_cover_ratio": 0.4490196151882506},
                     ],
-                    "marked_as_correct_by": [],
+                    "validated_by": [],
                 },
                 {
                     "rnb_id": self.bdg_two.rnb_id,
@@ -880,7 +880,7 @@ class BuildingsWithPlots(APITestCase):
                     "ext_ids": [],
                     "is_active": True,
                     "plots": [{"id": "two", "bdg_cover_ratio": 0.0016624281607746448}],
-                    "marked_as_correct_by": [],
+                    "validated_by": [],
                 },
             ],
         }
@@ -922,7 +922,7 @@ class BuildingsWithPlots(APITestCase):
         def list_buildings():
             self.client.get("/api/alpha/buildings/")
 
-        # 1 for the buildings, 1 for the related addresses, 1 for the marked_as_correct_by fields, 1 to log the call in rest_framework_tracking_apirequestlog
+        # 1 for the buildings, 1 for the related addresses, 1 for the validated_by fields, 1 to log the call in rest_framework_tracking_apirequestlog
         self.assertNumQueries(4, list_buildings)
 
     def test_single_bdg(self):
@@ -953,7 +953,7 @@ class BuildingsWithPlots(APITestCase):
                 {"id": "one", "bdg_cover_ratio": 0.529665644404105},
                 {"id": "two", "bdg_cover_ratio": 0.4490196151882506},
             ],
-            "marked_as_correct_by": [],
+            "validated_by": [],
         }
 
         # First we test with "withPlots" parameter = 1

--- a/app/api_alpha/tests/buildings/test_ogc.py
+++ b/app/api_alpha/tests/buildings/test_ogc.py
@@ -36,7 +36,7 @@ class OGCEndpointsTest(APITestCase):
             point=geom.point_on_surface,
             status="constructed",
         )
-        b.marked_as_correct_by = [self.user.id]
+        b.validated_by = [self.user.id]
         b.save()
 
         coords = {
@@ -258,7 +258,7 @@ class OGCEndpointsTest(APITestCase):
                         "ext_ids": None,
                         "addresses": [],
                         "is_active": True,
-                        "marked_as_correct_by": [
+                        "validated_by": [
                             {
                                 "display_name": get_display_name(self.user),
                                 "id": self.user.id,
@@ -292,7 +292,7 @@ class OGCEndpointsTest(APITestCase):
                         "ext_ids": None,
                         "addresses": [],
                         "is_active": True,
-                        "marked_as_correct_by": [],
+                        "validated_by": [],
                     },
                 },
             ],
@@ -354,7 +354,7 @@ class OGCEndpointsTest(APITestCase):
                         "ext_ids": None,
                         "addresses": [],
                         "is_active": True,
-                        "marked_as_correct_by": [
+                        "validated_by": [
                             {
                                 "display_name": get_display_name(self.user),
                                 "id": self.user.id,
@@ -430,7 +430,7 @@ class OGCEndpointsTest(APITestCase):
                         "ext_ids": None,
                         "addresses": [],
                         "is_active": True,
-                        "marked_as_correct_by": [],
+                        "validated_by": [],
                     },
                 },
             ],
@@ -487,7 +487,7 @@ class OGCEndpointsTest(APITestCase):
                         "ext_ids": None,
                         "addresses": [],
                         "is_active": True,
-                        "marked_as_correct_by": [],
+                        "validated_by": [],
                     },
                 },
             ],
@@ -536,7 +536,7 @@ class OGCEndpointsTest(APITestCase):
                     "ext_ids": None,
                     "addresses": [],
                     "is_active": True,
-                    "marked_as_correct_by": [],
+                    "validated_by": [],
                 },
             },
         )

--- a/app/api_alpha/tests/buildings/test_plots.py
+++ b/app/api_alpha/tests/buildings/test_plots.py
@@ -23,7 +23,7 @@ class BuildingPlotViewTest(APITestCase):
             status="demolished",
         )
         building_1.point = building_1.shape.point_on_surface
-        building_1.marked_as_correct_by = [user.id]
+        building_1.validated_by = [user.id]
         building_1.save()
         # inside plot 1 but inactive
         building_2 = Building.objects.create(
@@ -70,7 +70,7 @@ class BuildingPlotViewTest(APITestCase):
         [r1, r2, r3, r4] = data["results"]
         self.assertEqual(r1["rnb_id"], building_1.rnb_id)
         self.assertListEqual(
-            r1["marked_as_correct_by"],
+            r1["validated_by"],
             [
                 {
                     "display_name": get_display_name(user),

--- a/app/api_alpha/tests/buildings/test_single.py
+++ b/app/api_alpha/tests/buildings/test_single.py
@@ -53,7 +53,7 @@ class SingleBuildingTest(APITestCase):
                     "source_version": "25",
                 }
             ],
-            marked_as_correct_by=[u1.id, u2.id],
+            validated_by=[u1.id, u2.id],
         )
 
         Plot.objects.create(id="plot-1", shape=geom)
@@ -106,7 +106,7 @@ class SingleBuildingTest(APITestCase):
                 }
             ],
             "is_active": True,
-            "marked_as_correct_by": [
+            "validated_by": [
                 {
                     "display_name": "u1",
                     "id": User.objects.get(username="u1").id,
@@ -136,21 +136,21 @@ class SingleBuildingTest(APITestCase):
         self.assertEqual(r.data["properties"]["is_active"], True)
 
         self.assertListEqual(
-            list(r.data["properties"]["marked_as_correct_by"][0].keys()),
+            list(r.data["properties"]["validated_by"][0].keys()),
             ["display_name", "id", "username", "organization_name"],
         )
         self.assertEqual(
-            r.data["properties"]["marked_as_correct_by"][0]["display_name"], "u1"
+            r.data["properties"]["validated_by"][0]["display_name"], "u1"
         )
         self.assertEqual(
-            r.data["properties"]["marked_as_correct_by"][0]["username"], "u1"
+            r.data["properties"]["validated_by"][0]["username"], "u1"
         )
 
         self.assertEqual(
-            r.data["properties"]["marked_as_correct_by"][1]["display_name"], "u2"
+            r.data["properties"]["validated_by"][1]["display_name"], "u2"
         )
         self.assertEqual(
-            r.data["properties"]["marked_as_correct_by"][1]["username"], "u2"
+            r.data["properties"]["validated_by"][1]["username"], "u2"
         )
 
         self.assertListEqual(
@@ -195,13 +195,13 @@ class SingleBuildingTest(APITestCase):
             [{"id": "plot-1", "bdg_cover_ratio": 1}],
         )
 
-    def test_single_none_marked_as_correct_by(self):
+    def test_single_none_validated_by(self):
 
         b = Building.objects.get(rnb_id="1234ABCD5678")
-        b.marked_as_correct_by = None
+        b.validated_by = None
         b.save()
 
         r = self.client.get("/api/alpha/buildings/1234ABCD5678/")
         self.assertEqual(r.status_code, 200)
 
-        self.assertEqual(r.data["marked_as_correct_by"], [])
+        self.assertEqual(r.data["validated_by"], [])

--- a/app/api_alpha/tests/buildings/test_single.py
+++ b/app/api_alpha/tests/buildings/test_single.py
@@ -139,19 +139,11 @@ class SingleBuildingTest(APITestCase):
             list(r.data["properties"]["validated_by"][0].keys()),
             ["display_name", "id", "username", "organization_name"],
         )
-        self.assertEqual(
-            r.data["properties"]["validated_by"][0]["display_name"], "u1"
-        )
-        self.assertEqual(
-            r.data["properties"]["validated_by"][0]["username"], "u1"
-        )
+        self.assertEqual(r.data["properties"]["validated_by"][0]["display_name"], "u1")
+        self.assertEqual(r.data["properties"]["validated_by"][0]["username"], "u1")
 
-        self.assertEqual(
-            r.data["properties"]["validated_by"][1]["display_name"], "u2"
-        )
-        self.assertEqual(
-            r.data["properties"]["validated_by"][1]["username"], "u2"
-        )
+        self.assertEqual(r.data["properties"]["validated_by"][1]["display_name"], "u2")
+        self.assertEqual(r.data["properties"]["validated_by"][1]["username"], "u2")
 
         self.assertListEqual(
             r.data["properties"]["ext_ids"],

--- a/app/api_alpha/tests/buildings/test_update.py
+++ b/app/api_alpha/tests/buildings/test_update.py
@@ -775,13 +775,13 @@ class BuildingPatchValidateTest(APITestCase):
             validated_by=[],
         )
 
-    def test_validate_true_alone(self):
+    def test_is_valid_true_alone(self):
         """
-        Input: PATCH with only `validate=True`, building's validated_by is empty.
+        Input: PATCH with only `is_valid=True`, building's validated_by is empty.
         Expected: 204; the requesting user's id is appended to validated_by;
         a Contribution with status='fixed' is created and linked to the user.
         """
-        data = {"validate": True, "comment": "ce bâtiment est correct"}
+        data = {"is_valid": True, "comment": "ce bâtiment est correct"}
         r = self.client.patch(
             f"/api/alpha/buildings/{self.rnb_id}/",
             data=json.dumps(data),
@@ -797,16 +797,16 @@ class BuildingPatchValidateTest(APITestCase):
         self.assertEqual(contribution.review_user, self.user)
         self.assertEqual(contribution.text, "ce bâtiment est correct")
 
-    def test_validate_false_removes_user(self):
+    def test_is_valid_false_removes_user(self):
         """
         Input: building has the requesting user already in validated_by; PATCH
-        with only `validate=False`.
+        with only `is_valid=False`.
         Expected: 204; user.id is removed from validated_by.
         """
         self.building.validated_by = [self.user.id, self.other_user.id]
         self.building.save()
 
-        data = {"validate": False}
+        data = {"is_valid": False}
         r = self.client.patch(
             f"/api/alpha/buildings/{self.rnb_id}/",
             data=json.dumps(data),
@@ -820,13 +820,13 @@ class BuildingPatchValidateTest(APITestCase):
     def test_validate_false_idempotent_when_user_absent(self):
         """
         Input: building's validated_by does not contain the requesting user;
-        PATCH with only `validate=False`.
+        PATCH with only `is_valid=False`.
         Expected: 204 (no ValueError); validated_by stays unchanged.
         """
         self.building.validated_by = [self.other_user.id]
         self.building.save()
 
-        data = {"validate": False}
+        data = {"is_valid": False}
         r = self.client.patch(
             f"/api/alpha/buildings/{self.rnb_id}/",
             data=json.dumps(data),
@@ -837,10 +837,10 @@ class BuildingPatchValidateTest(APITestCase):
         self.building.refresh_from_db()
         self.assertEqual(self.building.validated_by, [self.other_user.id])
 
-    def test_validate_true_with_status_change_resets_list_and_adds_user(self):
+    def test_is_valid_true_with_status_change_resets_list_and_adds_user(self):
         """
         Input: building already has another user in validated_by; PATCH with
-        `validate=True` AND a new `status`.
+        `is_valid=True` AND a new `status`.
         Expected: 204; previous marks are cleared because the building changed, then
         the requesting user is appended — final list is [self.user.id]; status updated.
         """
@@ -849,7 +849,7 @@ class BuildingPatchValidateTest(APITestCase):
 
         data = {
             "status": "demolished",
-            "validate": True,
+            "is_valid": True,
             "comment": "démoli et je confirme",
         }
         r = self.client.patch(
@@ -863,15 +863,15 @@ class BuildingPatchValidateTest(APITestCase):
         self.assertEqual(self.building.status, "demolished")
         self.assertEqual(self.building.validated_by, [self.user.id])
 
-    def test_validate_with_is_active_rejected(self):
+    def test_is_valid_with_is_active_rejected(self):
         """
-        Input: PATCH combining `validate=True` with `is_active=False`.
+        Input: PATCH combining `is_valid=True` with `is_active=False`.
         Expected: 400 (validation error) — both fields are mutually exclusive; the
         building stays untouched.
         """
         data = {
             "is_active": False,
-            "validate": True,
+            "is_valid": True,
             "comment": "incompatible",
         }
         r = self.client.patch(
@@ -885,13 +885,13 @@ class BuildingPatchValidateTest(APITestCase):
         self.assertTrue(self.building.is_active)
         self.assertEqual(self.building.validated_by, [])
 
-    def test_validate_null_rejected(self):
+    def test_is_valid_null_rejected(self):
         """
-        Input: PATCH with `validate=None` (JSON null).
+        Input: PATCH with `is_valid=None` (JSON null).
         Expected: 400 — the serializer's BooleanField does not allow null
         (no `allow_null=True`); building stays untouched.
         """
-        data = {"validate": None}
+        data = {"is_valid": None}
         r = self.client.patch(
             f"/api/alpha/buildings/{self.rnb_id}/",
             data=json.dumps(data),

--- a/app/api_alpha/tests/buildings/test_update.py
+++ b/app/api_alpha/tests/buildings/test_update.py
@@ -756,8 +756,8 @@ class BuildingPatchTest(APITestCase):
             self.assertEqual(self.user.profile.total_contributions, 501)
 
 
-class BuildingPatchMarkAsCorrectTest(APITestCase):
-    """Tests for the `mark_as_correct` parameter on PATCH /api/alpha/buildings/<rnb_id>/."""
+class BuildingPatchValidateTest(APITestCase):
+    """Tests for the `validate` parameter on PATCH /api/alpha/buildings/<rnb_id>/."""
 
     def setUp(self) -> None:
         self.user = ContributorUserFactory(
@@ -772,16 +772,16 @@ class BuildingPatchMarkAsCorrectTest(APITestCase):
             rnb_id=self.rnb_id,
             status="constructed",
             shape=GEOSGeometry("POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))"),
-            marked_as_correct_by=[],
+            validated_by=[],
         )
 
-    def test_mark_as_correct_true_alone(self):
+    def test_validate_true_alone(self):
         """
-        Input: PATCH with only `mark_as_correct=True`, building's marked_as_correct_by is empty.
-        Expected: 204; the requesting user's id is appended to marked_as_correct_by;
+        Input: PATCH with only `validate=True`, building's validated_by is empty.
+        Expected: 204; the requesting user's id is appended to validated_by;
         a Contribution with status='fixed' is created and linked to the user.
         """
-        data = {"mark_as_correct": True, "comment": "ce bâtiment est correct"}
+        data = {"validate": True, "comment": "ce bâtiment est correct"}
         r = self.client.patch(
             f"/api/alpha/buildings/{self.rnb_id}/",
             data=json.dumps(data),
@@ -790,23 +790,23 @@ class BuildingPatchMarkAsCorrectTest(APITestCase):
 
         self.assertEqual(r.status_code, 204)
         self.building.refresh_from_db()
-        self.assertEqual(self.building.marked_as_correct_by, [self.user.id])
+        self.assertEqual(self.building.validated_by, [self.user.id])
 
         contribution = Contribution.objects.get(rnb_id=self.rnb_id)
         self.assertEqual(contribution.status, "fixed")
         self.assertEqual(contribution.review_user, self.user)
         self.assertEqual(contribution.text, "ce bâtiment est correct")
 
-    def test_mark_as_correct_false_removes_user(self):
+    def test_validate_false_removes_user(self):
         """
-        Input: building has the requesting user already in marked_as_correct_by; PATCH
-        with only `mark_as_correct=False`.
-        Expected: 204; user.id is removed from marked_as_correct_by.
+        Input: building has the requesting user already in validated_by; PATCH
+        with only `validate=False`.
+        Expected: 204; user.id is removed from validated_by.
         """
-        self.building.marked_as_correct_by = [self.user.id, self.other_user.id]
+        self.building.validated_by = [self.user.id, self.other_user.id]
         self.building.save()
 
-        data = {"mark_as_correct": False}
+        data = {"validate": False}
         r = self.client.patch(
             f"/api/alpha/buildings/{self.rnb_id}/",
             data=json.dumps(data),
@@ -815,18 +815,18 @@ class BuildingPatchMarkAsCorrectTest(APITestCase):
 
         self.assertEqual(r.status_code, 204)
         self.building.refresh_from_db()
-        self.assertEqual(self.building.marked_as_correct_by, [self.other_user.id])
+        self.assertEqual(self.building.validated_by, [self.other_user.id])
 
-    def test_mark_as_correct_false_idempotent_when_user_absent(self):
+    def test_validate_false_idempotent_when_user_absent(self):
         """
-        Input: building's marked_as_correct_by does not contain the requesting user;
-        PATCH with only `mark_as_correct=False`.
-        Expected: 204 (no ValueError); marked_as_correct_by stays unchanged.
+        Input: building's validated_by does not contain the requesting user;
+        PATCH with only `validate=False`.
+        Expected: 204 (no ValueError); validated_by stays unchanged.
         """
-        self.building.marked_as_correct_by = [self.other_user.id]
+        self.building.validated_by = [self.other_user.id]
         self.building.save()
 
-        data = {"mark_as_correct": False}
+        data = {"validate": False}
         r = self.client.patch(
             f"/api/alpha/buildings/{self.rnb_id}/",
             data=json.dumps(data),
@@ -835,21 +835,21 @@ class BuildingPatchMarkAsCorrectTest(APITestCase):
 
         self.assertEqual(r.status_code, 204)
         self.building.refresh_from_db()
-        self.assertEqual(self.building.marked_as_correct_by, [self.other_user.id])
+        self.assertEqual(self.building.validated_by, [self.other_user.id])
 
-    def test_mark_as_correct_true_with_status_change_resets_list_and_adds_user(self):
+    def test_validate_true_with_status_change_resets_list_and_adds_user(self):
         """
-        Input: building already has another user in marked_as_correct_by; PATCH with
-        `mark_as_correct=True` AND a new `status`.
+        Input: building already has another user in validated_by; PATCH with
+        `validate=True` AND a new `status`.
         Expected: 204; previous marks are cleared because the building changed, then
         the requesting user is appended — final list is [self.user.id]; status updated.
         """
-        self.building.marked_as_correct_by = [self.other_user.id]
+        self.building.validated_by = [self.other_user.id]
         self.building.save()
 
         data = {
             "status": "demolished",
-            "mark_as_correct": True,
+            "validate": True,
             "comment": "démoli et je confirme",
         }
         r = self.client.patch(
@@ -861,17 +861,17 @@ class BuildingPatchMarkAsCorrectTest(APITestCase):
         self.assertEqual(r.status_code, 204)
         self.building.refresh_from_db()
         self.assertEqual(self.building.status, "demolished")
-        self.assertEqual(self.building.marked_as_correct_by, [self.user.id])
+        self.assertEqual(self.building.validated_by, [self.user.id])
 
-    def test_mark_as_correct_with_is_active_rejected(self):
+    def test_validate_with_is_active_rejected(self):
         """
-        Input: PATCH combining `mark_as_correct=True` with `is_active=False`.
+        Input: PATCH combining `validate=True` with `is_active=False`.
         Expected: 400 (validation error) — both fields are mutually exclusive; the
         building stays untouched.
         """
         data = {
             "is_active": False,
-            "mark_as_correct": True,
+            "validate": True,
             "comment": "incompatible",
         }
         r = self.client.patch(
@@ -883,15 +883,15 @@ class BuildingPatchMarkAsCorrectTest(APITestCase):
         self.assertEqual(r.status_code, 400)
         self.building.refresh_from_db()
         self.assertTrue(self.building.is_active)
-        self.assertEqual(self.building.marked_as_correct_by, [])
+        self.assertEqual(self.building.validated_by, [])
 
-    def test_mark_as_correct_null_rejected(self):
+    def test_validate_null_rejected(self):
         """
-        Input: PATCH with `mark_as_correct=None` (JSON null).
+        Input: PATCH with `validate=None` (JSON null).
         Expected: 400 — the serializer's BooleanField does not allow null
         (no `allow_null=True`); building stays untouched.
         """
-        data = {"mark_as_correct": None}
+        data = {"validate": None}
         r = self.client.patch(
             f"/api/alpha/buildings/{self.rnb_id}/",
             data=json.dumps(data),
@@ -900,4 +900,4 @@ class BuildingPatchMarkAsCorrectTest(APITestCase):
 
         self.assertEqual(r.status_code, 400)
         self.building.refresh_from_db()
-        self.assertEqual(self.building.marked_as_correct_by, [])
+        self.assertEqual(self.building.validated_by, [])

--- a/app/api_alpha/tests/test_buildings.py
+++ b/app/api_alpha/tests/test_buildings.py
@@ -43,7 +43,7 @@ class BuildingClosestViewTest(APITestCase):
             ),
         )
 
-        closest_bdg.marked_as_correct_by = [user.id]
+        closest_bdg.validated_by = [user.id]
         closest_bdg.save()
 
         # It should appear second in the results
@@ -201,7 +201,7 @@ class BuildingClosestViewTest(APITestCase):
             data["results"][0]["shape"], json.loads(closest_bdg.shape.geojson)
         )
         self.assertListEqual(
-            data["results"][0]["marked_as_correct_by"],
+            data["results"][0]["validated_by"],
             [
                 {
                     "display_name": get_display_name(user),
@@ -419,7 +419,7 @@ class BuildingAddressViewTest(APITestCase):
             ),
         )
 
-        self.building_1.marked_as_correct_by = [self.user.id]
+        self.building_1.validated_by = [self.user.id]
         self.building_1.save()
 
         self.building_2 = Building.create_new(
@@ -494,7 +494,7 @@ class BuildingAddressViewTest(APITestCase):
             [r["rnb_id"] for r in data["results"]], [self.building_1.rnb_id]
         )
         self.assertListEqual(
-            data["results"][0]["marked_as_correct_by"],
+            data["results"][0]["validated_by"],
             [
                 {
                     "display_name": get_display_name(self.user),

--- a/app/api_alpha/tests/test_history.py
+++ b/app/api_alpha/tests/test_history.py
@@ -175,7 +175,7 @@ class SingleBuildingHistoryTest(APITestCase):
                 },
                 "ext_ids": [],
                 "updated_at": updated_at.isoformat().replace("+00:00", "Z"),
-                "marked_as_correct_by": [],
+                "validated_by": [],
             },
         )
 
@@ -630,10 +630,10 @@ class SingleBuildingHistoryTest(APITestCase):
         r = self.client.get(f"/api/alpha/buildings/1234ABCD1234/history/")
         self.assertEqual(r.status_code, 404)
 
-    def test_mark_as_correct(self):
+    def test_validate(self):
 
         data = {
-            "mark_as_correct": True,
+            "is_valid": True,
         }
         self.client.patch(
             f"/api/alpha/buildings/{self.rnb_id}/",
@@ -654,11 +654,11 @@ class SingleBuildingHistoryTest(APITestCase):
 
         self.assertEqual(
             data[0]["event"]["details"]["updated_fields"],
-            ["marked_as_correct_by"],
+            ["validated_by"],
         )
 
         self.assertListEqual(
-            data[0]["marked_as_correct_by"],
+            data[0]["validated_by"],
             [
                 {
                     "display_name": "Julie S.",

--- a/app/api_alpha/utils/rnb_doc.py
+++ b/app/api_alpha/utils/rnb_doc.py
@@ -349,9 +349,9 @@ def _get_components() -> dict:
                         "description": "Liste des adresses du bâtiment",
                         "items": {"$ref": "#/components/schemas/BuildingAddress"},
                     },
-                    "marked_as_correct_by": {
+                    "validated_by": {
                         "type": "array",
-                        "description": "Liste des utilisateurs ayant marqué ce bâtiment comme correct. Un bâtiment marqué comme correct par un utilisateur est un bâtiment que cet utilisateur considère comme correspondant à la définition d'un bâtiment et dont il pense que les attributs statut, géométrie et adresses sont corrects.",
+                        "description": "Liste des utilisateurs ayant validé ce bâtiment. Un bâtiment validé par un utilisateur est un bâtiment que cet utilisateur considère comme correspondant à la définition d'un bâtiment et dont il pense que les attributs statut, géométrie et adresses sont corrects.",
                         "items": {"$ref": "#/components/schemas/PublicUser"},
                     },
                     "ext_ids": {

--- a/app/api_alpha/views.py
+++ b/app/api_alpha/views.py
@@ -396,7 +396,7 @@ class BuildingAddressView(RNBLoggingMixin, APIView):
                 Building.objects.filter(is_active=True)
                 .filter(addresses_read_only__id=cle_interop_ban)
                 .prefetch_related("addresses_read_only")
-                .prefetch_related("marked_as_correct_read_only")
+                .prefetch_related("validated_by_read_only")
             )
             paginated_bdgs = paginator.paginate_queryset(buildings, request)
             serialized_buildings = BuildingSerializer(paginated_bdgs, many=True)

--- a/app/batid/list_bdg.py
+++ b/app/batid/list_bdg.py
@@ -173,9 +173,9 @@ def list_bdgs(params, only_active=True) -> QuerySet:
         )
         qs = qs.annotate(plots=PlotsAggSubquery(subquery))
 
-    # to prevent an ugly N+1 problem on the addresses and the marked_as_correct_by fields
+    # to prevent an ugly N+1 problem on the addresses and the validated_by fields
     qs = qs.prefetch_related("addresses_read_only")
-    qs = qs.prefetch_related("marked_as_correct_read_only")
+    qs = qs.prefetch_related("validated_by_read_only")
 
     return qs
 

--- a/app/batid/migrations/0137_rename_marked_as_correct_to_validated_by.py
+++ b/app/batid/migrations/0137_rename_marked_as_correct_to_validated_by.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.db import migrations, models
 
+from batid.migrations.utils.create_view import sql_migration_building_with_history
+
 
 class Migration(migrations.Migration):
 
@@ -111,4 +113,5 @@ class Migration(migrations.Migration):
                 "CREATE TRIGGER building_marked_as_correct_by_trigger AFTER INSERT OR UPDATE ON public.batid_building FOR EACH ROW EXECUTE FUNCTION keep_building_marked_as_correct_by_updated();",
             ],
         ),
+        sql_migration_building_with_history(),
     ]

--- a/app/batid/migrations/0137_rename_marked_as_correct_to_validated_by.py
+++ b/app/batid/migrations/0137_rename_marked_as_correct_to_validated_by.py
@@ -1,7 +1,6 @@
+from batid.migrations.utils.create_view import sql_migration_building_with_history
 from django.conf import settings
 from django.db import migrations, models
-
-from batid.migrations.utils.create_view import sql_migration_building_with_history
 
 
 class Migration(migrations.Migration):

--- a/app/batid/migrations/0137_rename_marked_as_correct_to_validated_by.py
+++ b/app/batid/migrations/0137_rename_marked_as_correct_to_validated_by.py
@@ -1,0 +1,114 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("batid", "0136_prevent_building_deletion"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="building",
+            old_name="marked_as_correct_by",
+            new_name="validated_by",
+        ),
+        migrations.RenameField(
+            model_name="buildinghistoryonly",
+            old_name="marked_as_correct_by",
+            new_name="validated_by",
+        ),
+        migrations.RenameModel(
+            old_name="BuildingMarkedAsCorrectByReadOnly",
+            new_name="BuildingValidatedByReadOnly",
+        ),
+        migrations.RenameField(
+            model_name="building",
+            old_name="marked_as_correct_read_only",
+            new_name="validated_by_read_only",
+        ),
+        migrations.AlterField(
+            model_name="building",
+            name="validated_by_read_only",
+            field=models.ManyToManyField(
+                blank=True,
+                related_name="buildings_validated_by_read_only",
+                through="batid.BuildingValidatedByReadOnly",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.RunSQL(
+            sql=[
+                "DROP TRIGGER IF EXISTS building_marked_as_correct_by_trigger ON batid_building;",
+                "DROP FUNCTION IF EXISTS keep_building_marked_as_correct_by_updated();",
+                """
+                CREATE OR REPLACE FUNCTION public.keep_building_validated_by_updated()
+                RETURNS trigger AS $$
+                DECLARE
+                    user_id INTEGER;
+                BEGIN
+                    IF TG_OP = 'INSERT' THEN
+                        IF (NEW.validated_by IS NOT NULL) THEN
+                            FOREACH user_id IN ARRAY NEW.validated_by
+                            LOOP
+                                INSERT INTO batid_buildingvalidatedbyreadonly (building_id, user_id)
+                                VALUES (NEW.id, user_id);
+                            END LOOP;
+                        END IF;
+                    ELSIF TG_OP = 'UPDATE' THEN
+                        IF NEW.validated_by IS DISTINCT FROM OLD.validated_by THEN
+                            DELETE FROM batid_buildingvalidatedbyreadonly WHERE building_id = NEW.id;
+                            IF (NEW.validated_by IS NOT NULL) THEN
+                                FOREACH user_id IN ARRAY NEW.validated_by
+                                LOOP
+                                    INSERT INTO batid_buildingvalidatedbyreadonly (building_id, user_id)
+                                    VALUES (NEW.id, user_id);
+                                END LOOP;
+                            END IF;
+                        END IF;
+                    END IF;
+                    RETURN NEW;
+                END;
+                $$ LANGUAGE plpgsql;
+                """,
+                "CREATE TRIGGER building_validated_by_trigger AFTER INSERT OR UPDATE ON public.batid_building FOR EACH ROW EXECUTE FUNCTION keep_building_validated_by_updated();",
+            ],
+            reverse_sql=[
+                "DROP TRIGGER IF EXISTS building_validated_by_trigger ON batid_building;",
+                "DROP FUNCTION IF EXISTS keep_building_validated_by_updated();",
+                """
+                CREATE OR REPLACE FUNCTION public.keep_building_marked_as_correct_by_updated()
+                RETURNS trigger AS $$
+                DECLARE
+                    user_id INTEGER;
+                BEGIN
+                    IF TG_OP = 'INSERT' THEN
+                        IF (NEW.marked_as_correct_by IS NOT NULL) THEN
+                            FOREACH user_id IN ARRAY NEW.marked_as_correct_by
+                            LOOP
+                                INSERT INTO batid_buildingmarkedascorrectbyreadonly (building_id, user_id)
+                                VALUES (NEW.id, user_id);
+                            END LOOP;
+                        END IF;
+                    ELSIF TG_OP = 'UPDATE' THEN
+                        IF NEW.marked_as_correct_by IS DISTINCT FROM OLD.marked_as_correct_by THEN
+                            DELETE FROM batid_buildingmarkedascorrectbyreadonly WHERE building_id = NEW.id;
+                            IF (NEW.marked_as_correct_by IS NOT NULL) THEN
+                                FOREACH user_id IN ARRAY NEW.marked_as_correct_by
+                                LOOP
+                                    INSERT INTO batid_buildingmarkedascorrectbyreadonly (building_id, user_id)
+                                    VALUES (NEW.id, user_id);
+                                END LOOP;
+                            END IF;
+                        END IF;
+                    END IF;
+                    RETURN NEW;
+                END;
+                $$ LANGUAGE plpgsql;
+                """,
+                "CREATE TRIGGER building_marked_as_correct_by_trigger AFTER INSERT OR UPDATE ON public.batid_building FOR EACH ROW EXECUTE FUNCTION keep_building_marked_as_correct_by_updated();",
+            ],
+        ),
+    ]

--- a/app/batid/models/building.py
+++ b/app/batid/models/building.py
@@ -537,7 +537,7 @@ class Building(BuildingAbstract):
         addresses_id: list,
         shape: GEOSGeometry,
         ext_ids: list,
-        mark_as_correct: bool = False,
+        is_valid: bool = False,
     ):
         check_and_increment_contribution_count(user)
 
@@ -578,7 +578,7 @@ class Building(BuildingAbstract):
             event_user=user,
             is_active=True,
             addresses_id=addresses_id,
-            marked_as_correct_by=[user.id] if mark_as_correct else [],
+            validated_by=[user.id] if is_valid else [],
         )
 
     @staticmethod

--- a/app/batid/models/building.py
+++ b/app/batid/models/building.py
@@ -98,7 +98,7 @@ class BuildingAbstract(models.Model):
     # this field is the source of truth for the building <> address link
     # it contains BAN ids (clé d'interopérabilité)
     addresses_id = ArrayField(models.CharField(max_length=40), null=True)
-    marked_as_correct_by = ArrayField(models.IntegerField(), null=True, default=list)
+    validated_by = ArrayField(models.IntegerField(), null=True, default=list)
 
     class Meta:
         abstract = True
@@ -120,11 +120,11 @@ class Building(BuildingAbstract):
         related_name="buildings_read_only",
         through="BuildingAddressesReadOnly",
     )
-    marked_as_correct_read_only = models.ManyToManyField(  # type: ignore[var-annotated]
+    validated_by_read_only = models.ManyToManyField(  # type: ignore[var-annotated]
         User,
         blank=True,
-        related_name="buildings_marked_as_correct_read_only",
-        through="BuildingMarkedAsCorrectByReadOnly",
+        related_name="buildings_validated_by_read_only",
+        through="BuildingValidatedByReadOnly",
     )
 
     def delete(self, *args, **kwargs):
@@ -349,7 +349,7 @@ class Building(BuildingAbstract):
         addresses_id: list | None,
         ext_ids: list | None = None,
         shape: GEOSGeometry | None = None,
-        mark_as_correct: bool | None = None,
+        validate: bool | None = None,
     ):
         check_and_increment_contribution_count(user)
 
@@ -363,27 +363,25 @@ class Building(BuildingAbstract):
             and (shape is None or shape == self.shape)
         )
 
-        if building_identical and mark_as_correct is None:
+        if building_identical and validate is None:
             # Nothing happens at all
             return
 
         if not building_identical:
-            # We changes the building, we consider previous "mark as correct" as wrong
-            marked_as_correct_by: list[int] = []
+            validated_by: list[int] = []
 
-            if mark_as_correct:
-                marked_as_correct_by.append(user.id)
-            self.marked_as_correct_by = marked_as_correct_by
+            if validate:
+                validated_by.append(user.id)
+            self.validated_by = validated_by
         else:
-            marked_as_correct_by = self.marked_as_correct_by or []
-            if mark_as_correct:
-                marked_as_correct_by.append(user.id)
-            elif user.id in marked_as_correct_by:
-                marked_as_correct_by.remove(user.id)
+            validated_by = self.validated_by or []
+            if validate:
+                validated_by.append(user.id)
+            elif user.id in validated_by:
+                validated_by.remove(user.id)
             else:
-                # mark_as_correct is False, but the building was not previously marked => no-op
                 return
-            self.marked_as_correct_by = marked_as_correct_by
+            self.validated_by = validated_by
 
         if not self.is_active:
             raise OperationOnInactiveBuilding(

--- a/app/batid/models/others.py
+++ b/app/batid/models/others.py
@@ -21,8 +21,7 @@ class BuildingAddressesReadOnly(models.Model):
         unique_together = ("building", "address")
 
 
-class BuildingMarkedAsCorrectByReadOnly(models.Model):
-    # buildings and users are never deleted
+class BuildingValidatedByReadOnly(models.Model):
     building = models.ForeignKey("Building", on_delete=models.PROTECT, db_index=True)
     user = models.ForeignKey(User, on_delete=models.PROTECT, db_index=True)
 

--- a/app/batid/services/bdg_history.py
+++ b/app/batid/services/bdg_history.py
@@ -217,7 +217,7 @@ def get_bdg_history(rnb_id: str) -> list[dict]:
     left join auth_user as u on bdg.event_user_id  = u.id
     LEFT JOIN LATERAL (
 		SELECT
-			prev.rnb_id, prev.status, prev.shape, prev.ext_ids, prev.addresses_id, prev.marked_as_correct_by
+			prev.rnb_id, prev.status, prev.shape, prev.ext_ids, prev.addresses_id, prev.validated_by
 		FROM batid_building_with_history AS prev
 		WHERE prev.rnb_id = bdg.rnb_id
 		AND lower(prev.sys_period) < lower(bdg.sys_period)

--- a/app/batid/services/bdg_history.py
+++ b/app/batid/services/bdg_history.py
@@ -32,8 +32,8 @@ def get_bdg_history(rnb_id: str) -> list[dict]:
         WHERE adr.id = ANY(bdg.addresses_id)
     ) as addresses,
 
-    -- The marked_as_correct_by part
-    -- Resolves each user id stored in bdg.marked_as_correct_by to {id, username, display_name, organization_name}
+    -- The validated_by part
+    -- Resolves each user id stored in bdg.validated_by to {id, username, display_name, organization_name}
     (
         SELECT COALESCE(json_agg(
             json_build_object(
@@ -55,8 +55,8 @@ def get_bdg_history(rnb_id: str) -> list[dict]:
             )
         ), '[]'::json)
         FROM auth_user AS mu
-        WHERE mu.id = ANY(bdg.marked_as_correct_by)
-    ) as marked_as_correct_by,
+        WHERE mu.id = ANY(bdg.validated_by)
+    ) as validated_by,
 
     -----------------------
     -----------------------
@@ -155,14 +155,14 @@ def get_bdg_history(rnb_id: str) -> list[dict]:
 	    			'shape', prev_data.shape,
 	    			'ext_ids', prev_data.ext_ids,
 	    			'addresses_id', prev_data.addresses_id,
-	    			'marked_as_correct_by', prev_data.marked_as_correct_by
+	    			'validated_by', prev_data.validated_by
 	    		),
                 'current_version', json_build_object(
 	    			'status', bdg.status,
 	    			'shape', bdg.shape,
 	    			'ext_ids', bdg.ext_ids,
 	    			'addresses_id', bdg.addresses_id,
-	    			'marked_as_correct_by', bdg.marked_as_correct_by
+	    			'validated_by', bdg.validated_by
                 )
 	    	)
 

--- a/app/batid/services/bdg_on_plot.py
+++ b/app/batid/services/bdg_on_plot.py
@@ -30,6 +30,6 @@ def get_buildings_on_plot(plot_id: str):
     )
 
     qs = qs.prefetch_related("addresses_read_only")
-    qs = qs.prefetch_related("marked_as_correct_read_only")
+    qs = qs.prefetch_related("validated_by_read_only")
 
     return qs

--- a/app/batid/services/closest_bdg.py
+++ b/app/batid/services/closest_bdg.py
@@ -53,7 +53,7 @@ def __get_qs(lat, lng, radius):
     )
 
     qs = qs.prefetch_related("addresses_read_only")
-    qs = qs.prefetch_related("marked_as_correct_read_only")
+    qs = qs.prefetch_related("validated_by_read_only")
     return qs
 
 

--- a/app/batid/services/vector_tiles/building.py
+++ b/app/batid/services/vector_tiles/building.py
@@ -46,7 +46,7 @@ def envelope_to_buildings_sql(
                    {attrColumns},
                    t.is_active AS is_active,
                    t.status AS status,
-                   COALESCE(array_length(t.marked_as_correct_by, 1), 0) > 0 AS is_marked_as_correct
+                   COALESCE(array_length(t.validated_by, 1), 0) > 0 AS is_validated
             FROM {table} t, bounds
             WHERE ST_Intersects(t.{geomColumn}, ST_Transform(bounds.geom, {srid}))
             {active_clause}

--- a/app/batid/tests/test_building_validated_by_link_trigger.py
+++ b/app/batid/tests/test_building_validated_by_link_trigger.py
@@ -1,24 +1,24 @@
-from batid.models import Building, BuildingMarkedAsCorrectByReadOnly
+from batid.models import Building, BuildingValidatedByReadOnly
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
 
 
-class BuildingMarkedAsCorrectLinkCase(TransactionTestCase):
-    def test_create_building_with_marked_as_correct_by(self):
+class BuildingValidatedByLinkCase(TransactionTestCase):
+    def test_create_building_with_validated_by(self):
         """
-        Input: a building is created with two users in marked_as_correct_by.
-        Expected: the postgres trigger inserts a row in BuildingMarkedAsCorrectByReadOnly
+        Input: a building is created with two users in validated_by.
+        Expected: the postgres trigger inserts a row in BuildingValidatedByReadOnly
         for each user.
         """
-        links_n = BuildingMarkedAsCorrectByReadOnly.objects.count()
+        links_n = BuildingValidatedByReadOnly.objects.count()
         self.assertEqual(links_n, 0)
 
         u1 = User.objects.create_user("alice", email="alice@example.com")
         u2 = User.objects.create_user("bob", email="bob@example.com")
 
-        b = Building.objects.create(rnb_id="1", marked_as_correct_by=[u1.id, u2.id])
+        b = Building.objects.create(rnb_id="1", validated_by=[u1.id, u2.id])
 
-        links = BuildingMarkedAsCorrectByReadOnly.objects.order_by("user_id")
+        links = BuildingValidatedByReadOnly.objects.order_by("user_id")
 
         self.assertEqual(links.count(), 2)
         self.assertEqual(links[0].building_id, b.id)
@@ -27,31 +27,31 @@ class BuildingMarkedAsCorrectLinkCase(TransactionTestCase):
         self.assertEqual(links[1].building_id, b.id)
         self.assertEqual(links[1].user_id, u2.id)
 
-    def test_create_building_with_empty_marked_as_correct_by(self):
+    def test_create_building_with_empty_validated_by(self):
         """
-        Input: a building is created with an empty marked_as_correct_by list (the default).
-        Expected: no link is created in BuildingMarkedAsCorrectByReadOnly.
+        Input: a building is created with an empty validated_by list (the default).
+        Expected: no link is created in BuildingValidatedByReadOnly.
         """
         b = Building.objects.create(rnb_id="1")
 
-        self.assertEqual(b.marked_as_correct_by, [])
-        self.assertEqual(BuildingMarkedAsCorrectByReadOnly.objects.count(), 0)
+        self.assertEqual(b.validated_by, [])
+        self.assertEqual(BuildingValidatedByReadOnly.objects.count(), 0)
 
     def test_update_building_add_users(self):
         """
-        Input: an existing building has its marked_as_correct_by updated to include users.
+        Input: an existing building has its validated_by updated to include users.
         Expected: the trigger creates a link for each user added.
         """
         u1 = User.objects.create_user("alice", email="alice@example.com")
         u2 = User.objects.create_user("bob", email="bob@example.com")
 
         b = Building.objects.create(rnb_id="1")
-        self.assertEqual(BuildingMarkedAsCorrectByReadOnly.objects.count(), 0)
+        self.assertEqual(BuildingValidatedByReadOnly.objects.count(), 0)
 
-        b.marked_as_correct_by = [u1.id, u2.id]
+        b.validated_by = [u1.id, u2.id]
         b.save()
 
-        links = BuildingMarkedAsCorrectByReadOnly.objects.order_by("user_id")
+        links = BuildingValidatedByReadOnly.objects.order_by("user_id")
 
         self.assertEqual(links.count(), 2)
         self.assertEqual(links[0].building_id, b.id)
@@ -62,54 +62,54 @@ class BuildingMarkedAsCorrectLinkCase(TransactionTestCase):
 
     def test_update_building_remove_one_user(self):
         """
-        Input: a building has two users in marked_as_correct_by; one is removed by saving
+        Input: a building has two users in validated_by; one is removed by saving
         a shorter array.
         Expected: only the link for the remaining user persists in the through table.
         """
         u1 = User.objects.create_user("alice", email="alice@example.com")
         u2 = User.objects.create_user("bob", email="bob@example.com")
 
-        b = Building.objects.create(rnb_id="1", marked_as_correct_by=[u1.id, u2.id])
-        self.assertEqual(BuildingMarkedAsCorrectByReadOnly.objects.count(), 2)
+        b = Building.objects.create(rnb_id="1", validated_by=[u1.id, u2.id])
+        self.assertEqual(BuildingValidatedByReadOnly.objects.count(), 2)
 
-        b.marked_as_correct_by = [u1.id]
+        b.validated_by = [u1.id]
         b.save()
 
-        links = BuildingMarkedAsCorrectByReadOnly.objects.all()
+        links = BuildingValidatedByReadOnly.objects.all()
         self.assertEqual(links.count(), 1)
         self.assertEqual(links[0].building_id, b.id)
         self.assertEqual(links[0].user_id, u1.id)
 
     def test_update_building_clear_with_empty_list(self):
         """
-        Input: marked_as_correct_by is updated from a non-empty list to an empty list.
+        Input: validated_by is updated from a non-empty list to an empty list.
         Expected: all existing links for the building are deleted by the trigger.
         """
         u1 = User.objects.create_user("alice", email="alice@example.com")
         u2 = User.objects.create_user("bob", email="bob@example.com")
 
-        b = Building.objects.create(rnb_id="1", marked_as_correct_by=[u1.id, u2.id])
-        self.assertEqual(BuildingMarkedAsCorrectByReadOnly.objects.count(), 2)
+        b = Building.objects.create(rnb_id="1", validated_by=[u1.id, u2.id])
+        self.assertEqual(BuildingValidatedByReadOnly.objects.count(), 2)
 
-        b.marked_as_correct_by = []
+        b.validated_by = []
         b.save()
 
-        self.assertEqual(BuildingMarkedAsCorrectByReadOnly.objects.count(), 0)
+        self.assertEqual(BuildingValidatedByReadOnly.objects.count(), 0)
 
     def test_update_building_clear_with_none(self):
         """
-        Input: marked_as_correct_by is updated from a non-empty list to None.
+        Input: validated_by is updated from a non-empty list to None.
         Expected: all existing links for the building are deleted by the trigger.
         """
         u1 = User.objects.create_user("alice", email="alice@example.com")
 
-        b = Building.objects.create(rnb_id="1", marked_as_correct_by=[u1.id])
-        self.assertEqual(BuildingMarkedAsCorrectByReadOnly.objects.count(), 1)
+        b = Building.objects.create(rnb_id="1", validated_by=[u1.id])
+        self.assertEqual(BuildingValidatedByReadOnly.objects.count(), 1)
 
-        b.marked_as_correct_by = None
+        b.validated_by = None
         b.save()
 
-        self.assertEqual(BuildingMarkedAsCorrectByReadOnly.objects.count(), 0)
+        self.assertEqual(BuildingValidatedByReadOnly.objects.count(), 0)
 
     def test_create_building_with_non_existing_user(self):
         """
@@ -122,27 +122,27 @@ class BuildingMarkedAsCorrectLinkCase(TransactionTestCase):
         u1 = User.objects.create_user("alice", email="alice@example.com")
 
         with self.assertRaises(IntegrityError):
-            Building.objects.create(rnb_id="1", marked_as_correct_by=[u1.id, 99999999])
+            Building.objects.create(rnb_id="1", validated_by=[u1.id, 99999999])
 
     def test_update_building_with_non_existing_user(self):
         """
-        Input: an existing building's marked_as_correct_by is updated to include a user
+        Input: an existing building's validated_by is updated to include a user
         id that does not exist.
         Expected: the trigger's insert into the through table fails with an IntegrityError.
         """
         from django.db.utils import IntegrityError
 
         u1 = User.objects.create_user("alice", email="alice@example.com")
-        b = Building.objects.create(rnb_id="1", marked_as_correct_by=[u1.id])
+        b = Building.objects.create(rnb_id="1", validated_by=[u1.id])
 
         with self.assertRaises(IntegrityError):
-            b.marked_as_correct_by = [u1.id, 99999999]
+            b.validated_by = [u1.id, 99999999]
             b.save()
 
     def test_create_building_with_duplicate_user(self):
         """
         Input: a building is created with the same user id repeated in
-        marked_as_correct_by.
+        validated_by.
         Expected: the trigger tries to insert the same (building, user) pair twice and
         violates the unique_together constraint, raising an IntegrityError.
         """
@@ -151,12 +151,12 @@ class BuildingMarkedAsCorrectLinkCase(TransactionTestCase):
         u1 = User.objects.create_user("alice", email="alice@example.com")
 
         with self.assertRaises(IntegrityError):
-            Building.objects.create(rnb_id="1", marked_as_correct_by=[u1.id, u1.id])
+            Building.objects.create(rnb_id="1", validated_by=[u1.id, u1.id])
 
     def test_update_building_with_duplicate_user(self):
         """
         Input: an existing building is updated to have the same user id repeated in
-        marked_as_correct_by.
+        validated_by.
         Expected: the trigger tries to insert the same (building, user) pair twice and
         violates the unique_together constraint, raising an IntegrityError.
         """
@@ -166,43 +166,43 @@ class BuildingMarkedAsCorrectLinkCase(TransactionTestCase):
         b = Building.objects.create(rnb_id="1")
 
         with self.assertRaises(IntegrityError):
-            b.marked_as_correct_by = [u1.id, u1.id]
+            b.validated_by = [u1.id, u1.id]
             b.save()
 
     def test_same_array_does_not_recreate_links(self):
         """
-        Input: a building is saved again with the exact same marked_as_correct_by content.
+        Input: a building is saved again with the exact same validated_by content.
         Expected: the trigger only fires the DELETE/INSERT branch when the array actually
         changes; the link rows keep their original ids.
         """
         u1 = User.objects.create_user("alice", email="alice@example.com")
 
-        b = Building.objects.create(rnb_id="1", marked_as_correct_by=[u1.id])
-        original_link_id = BuildingMarkedAsCorrectByReadOnly.objects.get(
+        b = Building.objects.create(rnb_id="1", validated_by=[u1.id])
+        original_link_id = BuildingValidatedByReadOnly.objects.get(
             building_id=b.id, user_id=u1.id
         ).id
 
-        b.marked_as_correct_by = [u1.id]
+        b.validated_by = [u1.id]
         b.save()
 
-        link = BuildingMarkedAsCorrectByReadOnly.objects.get(
+        link = BuildingValidatedByReadOnly.objects.get(
             building_id=b.id, user_id=u1.id
         )
         self.assertEqual(link.id, original_link_id)
 
 
-class UserMarkedAsCorrectDeletionCase(TransactionTestCase):
+class UserValidatedByDeletionCase(TransactionTestCase):
     def test_cannot_delete_user_linked_to_building(self):
         """
-        Input: a user is referenced in a building's marked_as_correct_by and the
+        Input: a user is referenced in a building's validated_by and the
         corresponding through-row exists.
         Expected: deleting the user raises (ProtectedError) because the foreign key
-        from BuildingMarkedAsCorrectByReadOnly to User uses on_delete=PROTECT.
+        from BuildingValidatedByReadOnly to User uses on_delete=PROTECT.
         """
         from django.db.models import ProtectedError
 
         u1 = User.objects.create_user("alice", email="alice@example.com")
-        Building.objects.create(rnb_id="1", marked_as_correct_by=[u1.id])
+        Building.objects.create(rnb_id="1", validated_by=[u1.id])
 
         with self.assertRaises(ProtectedError):
             u1.delete()
@@ -211,7 +211,7 @@ class UserMarkedAsCorrectDeletionCase(TransactionTestCase):
 
     def test_can_delete_user_never_linked(self):
         """
-        Input: a user who has never been added to any building's marked_as_correct_by.
+        Input: a user who has never been added to any building's validated_by.
         Expected: deletion succeeds.
         """
         u1 = User.objects.create_user("alice", email="alice@example.com")
@@ -221,14 +221,14 @@ class UserMarkedAsCorrectDeletionCase(TransactionTestCase):
 
     def test_can_delete_user_after_being_removed_from_array(self):
         """
-        Input: a user was in a building's marked_as_correct_by, then removed from the
+        Input: a user was in a building's validated_by, then removed from the
         array (which deletes the through-row via the trigger).
         Expected: the user can now be deleted because no through-row references them.
         """
         u1 = User.objects.create_user("alice", email="alice@example.com")
-        b = Building.objects.create(rnb_id="1", marked_as_correct_by=[u1.id])
+        b = Building.objects.create(rnb_id="1", validated_by=[u1.id])
 
-        b.marked_as_correct_by = []
+        b.validated_by = []
         b.save()
 
         u1.delete()

--- a/app/batid/tests/test_building_validated_by_link_trigger.py
+++ b/app/batid/tests/test_building_validated_by_link_trigger.py
@@ -185,9 +185,7 @@ class BuildingValidatedByLinkCase(TransactionTestCase):
         b.validated_by = [u1.id]
         b.save()
 
-        link = BuildingValidatedByReadOnly.objects.get(
-            building_id=b.id, user_id=u1.id
-        )
+        link = BuildingValidatedByReadOnly.objects.get(building_id=b.id, user_id=u1.id)
         self.assertEqual(link.id, original_link_id)
 
 

--- a/app/batid/tests/test_models.py
+++ b/app/batid/tests/test_models.py
@@ -808,33 +808,33 @@ class TestCreateNewBuildingMarkedAsCorrect(TestCase):
             **kwargs,
         )
 
-    def test_create_new_with_mark_as_correct_true(self):
+    def test_create_new_with_is_valid_true(self):
         """
-        Input: create_new called with mark_as_correct=True.
+        Input: create_new called with is_valid=True.
         Expected: the created building has the creating user's id in
-        marked_as_correct_by.
+        validated_by.
         """
-        b = self._create(mark_as_correct=True)
+        b = self._create(is_valid=True)
         b.refresh_from_db()
-        self.assertEqual(b.marked_as_correct_by, [self.user.id])
+        self.assertEqual(b.validated_by, [self.user.id])
 
-    def test_create_new_with_mark_as_correct_false(self):
+    def test_create_new_with_is_valid_false(self):
         """
-        Input: create_new called with mark_as_correct=False.
-        Expected: the created building has an empty marked_as_correct_by.
+        Input: create_new called with is_valid=False.
+        Expected: the created building has an empty validated_by.
         """
-        b = self._create(mark_as_correct=False)
+        b = self._create(is_valid=False)
         b.refresh_from_db()
-        self.assertEqual(b.marked_as_correct_by, [])
+        self.assertEqual(b.validated_by, [])
 
     def test_create_new_defaults_to_not_marked(self):
         """
-        Input: create_new called without the mark_as_correct argument.
-        Expected: marked_as_correct_by defaults to an empty list.
+        Input: create_new called without the is_valid argument.
+        Expected: validated_by defaults to an empty list.
         """
         b = self._create()
         b.refresh_from_db()
-        self.assertEqual(b.marked_as_correct_by, [])
+        self.assertEqual(b.validated_by, [])
 
 
 class TestSaveNewAddress(TestCase):

--- a/app/batid/tests/test_models.py
+++ b/app/batid/tests/test_models.py
@@ -549,8 +549,8 @@ class TestUpdateBuilding(TestCase):
             )
 
 
-class TestUpdateBuildingMarkedAsCorrect(TestCase):
-    """Tests for the marked_as_correct_by behavior in Building.update()."""
+class TestUpdateBuildingValidatedBy(TestCase):
+    """Tests for the validated_by behavior in Building.update()."""
 
     SHAPE_JSON = json.dumps(
         {
@@ -574,7 +574,7 @@ class TestUpdateBuildingMarkedAsCorrect(TestCase):
         self.user = ContributorUserFactory(username="solo_user")
         self.other_user = ContributorUserFactory(username="other_user")
 
-    def _create_building(self, marked_as_correct_by):
+    def _create_building(self, validated_by):
         b = Building.create_new(
             user=self.user,
             event_origin={"source": "test"},
@@ -583,28 +583,28 @@ class TestUpdateBuildingMarkedAsCorrect(TestCase):
             shape=GEOSGeometry(self.SHAPE_JSON),
             ext_ids=[],
         )
-        # Refresh so b.marked_as_correct_by is a fresh list from the DB rather
+        # Refresh so b.validated_by is a fresh list from the DB rather
         # than the shared field default, which would otherwise leak across tests.
         b.refresh_from_db()
-        for user in marked_as_correct_by:
+        for user in validated_by:
             b.update(
                 user=user,
                 event_origin={"source": "test"},
                 status=None,
                 addresses_id=None,
-                mark_as_correct=True,
+                validate=True,
             )
         b.refresh_from_db()
         return b
 
-    def test_update_changes_building_with_mark_as_correct_none_resets_list(self):
+    def test_update_changes_building_with_validate_none_resets_list(self):
         """
-        Input: an existing building has two users in marked_as_correct_by; update is
-        called with a real change (new status) and mark_as_correct=None.
-        Expected: marked_as_correct_by is reset to [] because the building content
+        Input: an existing building has two users in validated_by; update is
+        called with a real change (new status) and validate=None.
+        Expected: validated_by is reset to [] because the building content
         changed, so any previous "this is correct" mark is no longer meaningful.
         """
-        b = self._create_building(marked_as_correct_by=[self.user, self.other_user])
+        b = self._create_building(validated_by=[self.user, self.other_user])
 
         b.update(
             user=self.user,
@@ -613,99 +613,99 @@ class TestUpdateBuildingMarkedAsCorrect(TestCase):
             addresses_id=None,
         )
         b.refresh_from_db()
-        self.assertEqual(b.marked_as_correct_by, [])
+        self.assertEqual(b.validated_by, [])
 
-    def test_update_changes_building_with_mark_as_correct_true_resets_and_adds_user(
+    def test_update_changes_building_with_validate_true_resets_and_adds_user(
         self,
     ):
         """
-        Input: an existing building has other_user in marked_as_correct_by; update is
-        called with a real change (new status) and mark_as_correct=True from self.user.
+        Input: an existing building has other_user in validated_by; update is
+        called with a real change (new status) and validate=True from self.user.
         Expected: previous marks are cleared, then self.user.id is appended; the final
         list contains only self.user.id.
         """
-        b = self._create_building(marked_as_correct_by=[self.other_user])
+        b = self._create_building(validated_by=[self.other_user])
 
         b.update(
             user=self.user,
             event_origin={"source": "test"},
             status="demolished",
             addresses_id=None,
-            mark_as_correct=True,
+            validate=True,
         )
         b.refresh_from_db()
-        self.assertEqual(b.marked_as_correct_by, [self.user.id])
+        self.assertEqual(b.validated_by, [self.user.id])
 
-    def test_update_changes_building_with_mark_as_correct_false_resets_list(self):
+    def test_update_changes_building_with_validate_false_resets_list(self):
         """
-        Input: an existing building has two users in marked_as_correct_by; update is
-        called with a real change (new status) and mark_as_correct=False.
-        Expected: marked_as_correct_by is reset to []; mark_as_correct=False is falsy,
+        Input: an existing building has two users in validated_by; update is
+        called with a real change (new status) and validate=False.
+        Expected: validated_by is reset to []; validate=False is falsy,
         so no user is appended after the reset.
         """
-        b = self._create_building(marked_as_correct_by=[self.user, self.other_user])
+        b = self._create_building(validated_by=[self.user, self.other_user])
 
         b.update(
             user=self.user,
             event_origin={"source": "test"},
             status="demolished",
             addresses_id=None,
-            mark_as_correct=False,
+            validate=False,
         )
         b.refresh_from_db()
-        self.assertEqual(b.marked_as_correct_by, [])
+        self.assertEqual(b.validated_by, [])
 
-    def test_update_identical_with_mark_as_correct_true_appends_user(self):
+    def test_update_identical_with_validate_true_appends_user(self):
         """
-        Input: an existing building has other_user in marked_as_correct_by; update is
-        called with no real change and mark_as_correct=True from self.user.
+        Input: an existing building has other_user in validated_by; update is
+        called with no real change and validate=True from self.user.
         Expected: self.user.id is appended to the existing list; the final list
         contains both users.
         """
-        b = self._create_building(marked_as_correct_by=[self.other_user])
+        b = self._create_building(validated_by=[self.other_user])
 
         b.update(
             user=self.user,
             event_origin={"source": "test"},
             status=None,
             addresses_id=None,
-            mark_as_correct=True,
+            validate=True,
         )
         b.refresh_from_db()
         self.assertEqual(
-            sorted(b.marked_as_correct_by),
+            sorted(b.validated_by),
             sorted([self.other_user.id, self.user.id]),
         )
 
-    def test_update_identical_with_mark_as_correct_false_removes_user(self):
+    def test_update_identical_with_validate_false_removes_user(self):
         """
-        Input: an existing building has self.user and other_user in marked_as_correct_by;
-        update is called with no real change and mark_as_correct=False from self.user.
+        Input: an existing building has self.user and other_user in validated_by;
+        update is called with no real change and validate=False from self.user.
         Expected: self.user.id is removed; only other_user.id remains.
         """
-        b = self._create_building(marked_as_correct_by=[self.user, self.other_user])
+        b = self._create_building(validated_by=[self.user, self.other_user])
 
         b.update(
             user=self.user,
             event_origin={"source": "test"},
             status=None,
             addresses_id=None,
-            mark_as_correct=False,
+            validate=False,
         )
         b.refresh_from_db()
-        self.assertEqual(b.marked_as_correct_by, [self.other_user.id])
+        self.assertEqual(b.validated_by, [self.other_user.id])
 
-    def test_update_identical_with_mark_as_correct_false_not_previously_marked_is_noop(
+    def test_update_identical_with_validate_false_not_previously_marked_is_noop(
         self,
     ):
         """
-        Input: an existing building has only other_user in marked_as_correct_by;
-        update is called with no real change and mark_as_correct=False from self.user
-        (who was never in marked_as_correct_by).
-        Expected: the call is a complete no-op — marked_as_correct_by is unchanged
+        Input: an existing building has only other_user in validated_by;
+        update is called with no real change and validate=False from self.user
+        (who was never in validated_by).
+        Expected: the call is a complete no-op — validated_by is unchanged
         and no new history row is written (sys_period stays the same).
         """
-        b = self._create_building(marked_as_correct_by=[self.other_user])
+        b = self._create_building(validated_by=[self.other_user])
         b.refresh_from_db()
         sys_period_before = b.sys_period
 
@@ -714,20 +714,20 @@ class TestUpdateBuildingMarkedAsCorrect(TestCase):
             event_origin={"source": "test"},
             status=None,
             addresses_id=None,
-            mark_as_correct=False,
+            validate=False,
         )
         b.refresh_from_db()
-        self.assertEqual(b.marked_as_correct_by, [self.other_user.id])
+        self.assertEqual(b.validated_by, [self.other_user.id])
         self.assertEqual(b.sys_period, sys_period_before)
 
-    def test_update_identical_with_mark_as_correct_none_is_noop(self):
+    def test_update_identical_with_validate_none_is_noop(self):
         """
-        Input: an existing building has other_user in marked_as_correct_by; update is
-        called with no real change and mark_as_correct=None.
-        Expected: the call is a complete no-op — marked_as_correct_by is unchanged and
+        Input: an existing building has other_user in validated_by; update is
+        called with no real change and validate=None.
+        Expected: the call is a complete no-op — validated_by is unchanged and
         no new history row is written (sys_period stays the same).
         """
-        b = self._create_building(marked_as_correct_by=[self.other_user])
+        b = self._create_building(validated_by=[self.other_user])
         # refresh to read the DB-side sys_period (the temporal trigger overrides
         # the Python-side default at insert time)
         b.refresh_from_db()
@@ -738,40 +738,40 @@ class TestUpdateBuildingMarkedAsCorrect(TestCase):
             event_origin={"source": "test"},
             status=None,
             addresses_id=None,
-            mark_as_correct=None,
+            validate=None,
         )
         b.refresh_from_db()
-        self.assertEqual(b.marked_as_correct_by, [self.other_user.id])
+        self.assertEqual(b.validated_by, [self.other_user.id])
         self.assertEqual(b.sys_period, sys_period_before)
 
-    def test_update_identical_mark_as_correct_true_from_two_users_accumulates(self):
+    def test_update_identical_validate_true_from_two_users_accumulates(self):
         """
-        Input: a fresh building with empty marked_as_correct_by; two different users
-        successively call update with no real change and mark_as_correct=True.
-        Expected: both user ids end up in marked_as_correct_by, in the order they
+        Input: a fresh building with empty validated_by; two different users
+        successively call update with no real change and validate=True.
+        Expected: both user ids end up in validated_by, in the order they
         were added.
         """
-        b = self._create_building(marked_as_correct_by=[])
+        b = self._create_building(validated_by=[])
 
         b.update(
             user=self.user,
             event_origin={"source": "test"},
             status=None,
             addresses_id=None,
-            mark_as_correct=True,
+            validate=True,
         )
         b.refresh_from_db()
-        self.assertEqual(b.marked_as_correct_by, [self.user.id])
+        self.assertEqual(b.validated_by, [self.user.id])
 
         b.update(
             user=self.other_user,
             event_origin={"source": "test"},
             status=None,
             addresses_id=None,
-            mark_as_correct=True,
+            validate=True,
         )
         b.refresh_from_db()
-        self.assertEqual(b.marked_as_correct_by, [self.user.id, self.other_user.id])
+        self.assertEqual(b.validated_by, [self.user.id, self.other_user.id])
 
 
 class TestCreateNewBuildingMarkedAsCorrect(TestCase):

--- a/app/batid/tests/test_temporal_table_building.py
+++ b/app/batid/tests/test_temporal_table_building.py
@@ -11,12 +11,12 @@ class TemporalTableCase(TransactionTestCase):
         building = Building.objects.create(rnb_id="XYZ")
         # We now update the building (and so create a new version of it)
         building.parent_buildings = [1]
-        building.marked_as_correct_by = [user.id]
+        building.validated_by = [user.id]
         building.save()
 
         building.refresh_from_db()
         self.assertEqual(building.parent_buildings, [1])
-        self.assertEqual(building.marked_as_correct_by, [user.id])
+        self.assertEqual(building.validated_by, [user.id])
 
         building_versions = BuildingWithHistory.objects.filter(rnb_id="XYZ")
         # the actual value is present, but also the previous one
@@ -28,27 +28,27 @@ class TemporalTableCase(TransactionTestCase):
         ).all()
         self.assertEqual(len(previous_building_version), 1)
         self.assertEqual(previous_building_version[0].parent_buildings, None)
-        self.assertEqual(previous_building_version[0].marked_as_correct_by, [])
+        self.assertEqual(previous_building_version[0].validated_by, [])
 
         current_building_version = BuildingWithHistory.objects.filter(
             sys_period__endswith__isnull=True
         )
         self.assertEqual(len(current_building_version), 1)
         self.assertEqual(current_building_version[0].parent_buildings, [1])
-        self.assertEqual(current_building_version[0].marked_as_correct_by, [user.id])
+        self.assertEqual(current_building_version[0].validated_by, [user.id])
 
         building_history_only = BuildingHistoryOnly.objects.all()
         self.assertEqual(len(building_history_only), 1)
-        self.assertEqual(building_history_only[0].marked_as_correct_by, [])
+        self.assertEqual(building_history_only[0].validated_by, [])
 
-        # save the building a second time to make sure the marked_as_correct_by
+        # save the building a second time to make sure the validated_by
         # value carried over to history is not always the default empty list
         other_user = User.objects.create_user("bob", email="bob@example.com")
-        building.marked_as_correct_by = [user.id, other_user.id]
+        building.validated_by = [user.id, other_user.id]
         building.save()
 
         building.refresh_from_db()
-        self.assertEqual(building.marked_as_correct_by, [user.id, other_user.id])
+        self.assertEqual(building.validated_by, [user.id, other_user.id])
 
         # there are now three versions: two historicized + the current one
         self.assertEqual(BuildingWithHistory.objects.filter(rnb_id="XYZ").count(), 3)
@@ -62,12 +62,12 @@ class TemporalTableCase(TransactionTestCase):
             .order_by("-sys_period")
             .first()
         )
-        self.assertEqual(latest_historicized.marked_as_correct_by, [user.id])
+        self.assertEqual(latest_historicized.validated_by, [user.id])
 
         current = BuildingWithHistory.objects.get(
             rnb_id="XYZ", sys_period__endswith__isnull=True
         )
-        self.assertEqual(current.marked_as_correct_by, [user.id, other_user.id])
+        self.assertEqual(current.validated_by, [user.id, other_user.id])
 
     def test_history_is_read_only(self):
         # trying to manually insert a new row in the history table should raise an exception

--- a/app/batid/tests/test_tiles.py
+++ b/app/batid/tests/test_tiles.py
@@ -77,10 +77,6 @@ class TestVectorTiles(TestCase):
 
         features = self._features_by_rnb_id(response.content)
         self.assertEqual(set(features.keys()), {"BDG-MARKED", "BDG-EMPTY", "BDG-NULL"})
-        self.assertIs(
-            features["BDG-MARKED"]["properties"]["is_validated"], True
-        )
-        self.assertIs(
-            features["BDG-EMPTY"]["properties"]["is_validated"], False
-        )
+        self.assertIs(features["BDG-MARKED"]["properties"]["is_validated"], True)
+        self.assertIs(features["BDG-EMPTY"]["properties"]["is_validated"], False)
         self.assertIs(features["BDG-NULL"]["properties"]["is_validated"], False)

--- a/app/batid/tests/test_tiles.py
+++ b/app/batid/tests/test_tiles.py
@@ -14,21 +14,21 @@ class TestVectorTiles(TestCase):
             status="constructed",
             point="POINT (2.6000591402070654 48.814763140563656)",
             is_active=True,
-            marked_as_correct_by=[user.pk],
+            validated_by=[user.pk],
         )
         Building.objects.create(
             rnb_id="BDG-EMPTY",
             status="constructed",
             point="POINT (2.6001591402070654 48.814863140563656)",
             is_active=True,
-            marked_as_correct_by=[],
+            validated_by=[],
         )
         Building.objects.create(
             rnb_id="BDG-NULL",
             status="constructed",
             point="POINT (2.6002591402070654 48.814963140563656)",
             is_active=True,
-            marked_as_correct_by=None,
+            validated_by=None,
         )
 
     def _features_by_rnb_id(self, tile_bytes):
@@ -64,12 +64,12 @@ class TestVectorTiles(TestCase):
         )
         self.assertEqual(zoomed_in_response.status_code, 200)
 
-    def test_tile_is_marked_as_correct_property(self):
+    def test_tile_is_validated_property(self):
         """
         Input: three active constructed buildings (set up in setUp) in tile
-        33241/22557/16, one with marked_as_correct_by populated with a real
+        33241/22557/16, one with validated_by populated with a real
         user id, one with an empty list, one with NULL.
-        Expected: the decoded MVT exposes is_marked_as_correct True only for
+        Expected: the decoded MVT exposes is_validated True only for
         the populated one; empty list and NULL both yield False.
         """
         response = self.client.get("/api/alpha/tiles/33241/22557/16.pbf")
@@ -78,9 +78,9 @@ class TestVectorTiles(TestCase):
         features = self._features_by_rnb_id(response.content)
         self.assertEqual(set(features.keys()), {"BDG-MARKED", "BDG-EMPTY", "BDG-NULL"})
         self.assertIs(
-            features["BDG-MARKED"]["properties"]["is_marked_as_correct"], True
+            features["BDG-MARKED"]["properties"]["is_validated"], True
         )
         self.assertIs(
-            features["BDG-EMPTY"]["properties"]["is_marked_as_correct"], False
+            features["BDG-EMPTY"]["properties"]["is_validated"], False
         )
-        self.assertIs(features["BDG-NULL"]["properties"]["is_marked_as_correct"], False)
+        self.assertIs(features["BDG-NULL"]["properties"]["is_validated"], False)


### PR DESCRIPTION
Je renomme tout ce qui est "marquer comme correct" en "valider".

Un point à noter : on ne peut pas utiliser `validate` dans les champ d'un serializer DRF. C'est un nom réservé. J'utilise `is_valid`. Ca me semble ok et c'est assez cohérent avec `is_active`.