### PR TITLE
Publication data.gouv du RNB historisé

### DIFF
--- a/app/batid/services/data_gouv_publication.py
+++ b/app/batid/services/data_gouv_publication.py
@@ -15,17 +15,21 @@ from django.db import connection, transaction
 from app.settings import WRITABLE_DATA_DIR
 
 
-def publish(area: str):
+def publish(area: str, only_active=True):
     print(f"Processing area: {area}")
 
     try:
-        directory_name = create_directory(area)
-        create_csv(directory_name, area)
-        archive_path, archive_size, archive_sha1 = create_archive(directory_name, area)
+        directory_name = create_directory(area, only_active)
+        create_csv(directory_name, area, only_active)
+        archive_path, archive_size, archive_sha1 = create_archive(
+            directory_name, area, only_active
+        )
 
         if os.environ.get("ENABLE_DATAGOUV_PUBLICATION") == "true":
             public_url = upload_to_s3(archive_path)
-            publish_on_data_gouv(area, public_url, archive_size, archive_sha1)
+            publish_on_data_gouv(
+                area, only_active, public_url, archive_size, archive_sha1
+            )
     except Exception as e:
         logging.error(
             f"Error while publishing the RNB for area {area} on data.gouv.fr: {e}"
@@ -37,27 +41,72 @@ def publish(area: str):
     return True
 
 
-def create_directory(area):
-    directory_name = (
-        f'datagouvfr_publication_{area}_{datetime.now().strftime("%Y-%m-%d_%H-%M-%S")}'
-    )
+def create_directory(area: str, only_active: bool):
+    directory_name = f'datagouvfr_publication_{area}{'' if only_active else '_full'}_{datetime.now().strftime("%Y-%m-%d_%H-%M-%S")}'
     directory_path = os.path.join(WRITABLE_DATA_DIR, directory_name)
     os.makedirs(directory_path, exist_ok=True)
     return directory_path
 
 
+# Return the base file name (WITHOUT directory and extension)
+def file_name(code_area, only_active: bool):
+    return f"RNB_{code_area}{'' if only_active else '_full'}"
+
+
 # Return the global path of a file WITHOUT the extension
-def file_path(directory_name, code_area):
-    return directory_name + "/RNB_" + str(code_area)
+def file_path(directory_name, code_area, only_active: bool):
+    return directory_name + "/" + file_name(code_area, only_active)
 
 
-def sql_query(code_area):
+def dpt_clauses(code_area: str):
+    """Return the (join, where) SQL fragments restricting an export to a department.
+
+    For the national export ("nat") both fragments are empty.
+    """
     if code_area == "nat":
-        dpt_where = ""
-        dpt_join = ""
-    else:
-        dpt_where = f" AND dpt.code = '{code_area}'"
-        dpt_join = " LEFT JOIN batid_department_subdivided AS dpt ON ST_Intersects(dpt.shape, bdg.point)"
+        return "", ""
+
+    dpt_join = " LEFT JOIN batid_department_subdivided AS dpt ON ST_Intersects(dpt.shape, bdg.point)"
+    dpt_where = f" AND dpt.code = '{code_area}'"
+    return dpt_join, dpt_where
+
+
+# Scalar subquery computing the cadastral plots covered by the building shape.
+# Correlated on bdg.shape, so it must be embedded in the main query.
+PLOTS_SUBQUERY = """
+        (
+           SELECT json_agg(json_build_object('id', p.id, 'bdg_cover_ratio',
+               CASE
+                   WHEN ST_GeometryType(bdg.shape) = 'ST_Point' THEN 1.0
+                   WHEN ST_GeometryType(bdg.shape) IN ('ST_Polygon', 'ST_MultiPolygon') THEN
+                       CASE
+                           WHEN ST_Area(bdg.shape) > 0 THEN
+                               ST_Area(ST_Intersection(bdg.shape, p.shape)) / ST_Area(bdg.shape)
+                           ELSE 0.0
+                       END
+                   ELSE 0.0
+               END
+           ))
+           FROM batid_plot p
+           WHERE ST_Intersects(p.shape, bdg.shape)
+       )
+"""
+
+
+def sql_query(code_area: str, only_active: bool):
+    if only_active:
+        return sql_query_active(code_area)
+    return sql_query_full(code_area)
+
+
+def sql_query_active(code_area: str):
+    """Export of the currently active buildings only.
+
+    Addresses come from the batid_buildingaddressesreadonly link table, which
+    only reflects the current version of each building (enough here, since we
+    only export active/current buildings).
+    """
+    dpt_join, dpt_where = dpt_clauses(code_area)
 
     sql = f"""
     COPY (
@@ -77,22 +126,7 @@ def sql_query(code_area):
                 )
 
         ) FILTER (WHERE addr.id IS NOT NULL), '[]'::json) AS addresses,
-        (
-           SELECT json_agg(json_build_object('id', p.id, 'bdg_cover_ratio',
-               CASE
-                   WHEN ST_GeometryType(bdg.shape) = 'ST_Point' THEN 1.0
-                   WHEN ST_GeometryType(bdg.shape) IN ('ST_Polygon', 'ST_MultiPolygon') THEN
-                       CASE
-                           WHEN ST_Area(bdg.shape) > 0 THEN
-                               ST_Area(ST_Intersection(bdg.shape, p.shape)) / ST_Area(bdg.shape)
-                           ELSE 0.0
-                       END
-                   ELSE 0.0
-               END
-           ))
-           FROM batid_plot p
-           WHERE ST_Intersects(p.shape, bdg.shape)
-       ) AS plots
+        {PLOTS_SUBQUERY} AS plots
         FROM batid_building bdg
         LEFT JOIN batid_buildingaddressesreadonly bdg_addr ON bdg_addr.building_id = bdg.id
         LEFT JOIN batid_address addr ON addr.id = bdg_addr.address_id
@@ -106,10 +140,69 @@ def sql_query(code_area):
     return sql
 
 
-def create_csv(directory_name, code_area):
-    sql = sql_query(code_area)
+def sql_query_full(code_area: str):
+    """Full export of every building version, current AND historical.
+
+    Sourced from the batid_building_with_history view. Addresses are rebuilt
+    from the bdg.addresses_id array (the historized source of truth for the
+    building <> address link) instead of the readonly link table, so each
+    historical version carries the addresses it actually had at the time.
+    Internal user ids (event_user_id, validated_by) are resolved to usernames.
+    """
+    dpt_join, dpt_where = dpt_clauses(code_area)
+
+    sql = f"""
+    COPY (
+        select bdg.rnb_id as rnb_id,
+        ST_AsEWKT(bdg.point) as point,
+        ST_AsEWKT(bdg.shape) as shape,
+        bdg.status as status,
+        bdg.ext_ids as ext_ids,
+        bdg.is_active as is_active,
+        bdg.sys_period as sys_period,
+        bdg.event_type as event_type,
+        bdg.event_id as event_id,
+        bdg.revert_event_id as revert_event_id,
+        bdg.event_origin as event_origin,
+        bdg.parent_buildings as parent_buildings,
+        bdg.created_at as created_at,
+        bdg.updated_at as updated_at,
+        eu.username as event_user,
+        (
+            SELECT array_agg(u.username)
+            FROM auth_user u
+            WHERE u.id = ANY(bdg.validated_by)
+        ) as validated_by,
+        (
+            SELECT coalesce(json_agg(
+                json_build_object(
+                    'cle_interop_ban', a.cle,
+                    'street_number', addr.street_number,
+                    'street_rep', addr.street_rep,
+                    'street', addr.street,
+                    'city_zipcode', addr.city_zipcode,
+                    'city_name', addr.city_name
+                ) ORDER BY a.ord
+            ), '[]'::json)
+            FROM unnest(bdg.addresses_id) WITH ORDINALITY AS a(cle, ord)
+            LEFT JOIN batid_address addr ON addr.id = a.cle
+        ) AS addresses,
+        {PLOTS_SUBQUERY} AS plots
+        FROM batid_building_with_history bdg
+        LEFT JOIN auth_user eu ON eu.id = bdg.event_user_id
+        {dpt_join}
+        WHERE TRUE
+        {dpt_where}
+    )  TO STDOUT WITH CSV HEADER DELIMITER ';'
+    """
+
+    return sql
+
+
+def create_csv(directory_name: str, code_area: str, only_active: bool):
+    sql = sql_query(code_area, only_active)
     local_statement_timeout = settings.DATA_GOUV_POSTGRES_STATEMENT_TIMEOUT
-    with open(f"{file_path(directory_name, code_area)}.csv", "w") as fp:
+    with open(f"{file_path(directory_name, code_area, only_active)}.csv", "w") as fp:
         with transaction.atomic():
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -129,12 +222,15 @@ def sha1sum(filename):
     return h.hexdigest()
 
 
-def create_archive(directory_name, code_area):
+def create_archive(directory_name, code_area, only_active: bool):
     files = os.listdir(directory_name)
-    archive_path = f"{file_path(directory_name, code_area)}.csv.zip"
+    archive_path = f"{file_path(directory_name, code_area, only_active)}.csv.zip"
 
     with ZipFile(archive_path, "w", ZIP_DEFLATED) as zip:
-        zip.write(f"{file_path(directory_name, code_area)}.csv", f"RNB_{code_area}.csv")
+        zip.write(
+            f"{file_path(directory_name, code_area, only_active)}.csv",
+            f"{file_name(code_area, only_active)}.csv",
+        )
 
     archive_size = os.path.getsize(archive_path)
 
@@ -189,19 +285,36 @@ def upload_to_s3(archive_path):
     return public_url
 
 
-def publish_on_data_gouv(area, public_url, archive_size, archive_sha1, format="zip"):
-    # publish the archive on data.gouv.fr
-    dataset_id = os.environ.get("DATA_GOUV_DATASET_ID")
-    resource_id = data_gouv_resource_id(dataset_id, area)
-
+def resource_title(area, only_active: bool):
     if area == "nat":
         title = "Export National"
+    else:
+        title = f"Export Départemental {area}"
+
+    if not only_active:
+        title += " (avec historique)"
+
+    return title
+
+
+def publish_on_data_gouv(
+    area, only_active: bool, public_url, archive_size, archive_sha1, format="zip"
+):
+    # publish the archive on data.gouv.fr
+    dataset_id = os.environ.get("DATA_GOUV_DATASET_ID")
+    resource_id = data_gouv_resource_id(dataset_id, area, only_active)
+
+    title = resource_title(area, only_active)
+
+    if area == "nat":
         description = (
             "Export du RNB au format csv pour l’ensemble du territoire français."
         )
     else:
-        title = f"Export Départemental {area}"
         description = f"Export du RNB au format csv pour le département {area}."
+
+    if not only_active:
+        description += " Cet export contient les ID-RNB actuellement actifs du RNB, mais également tous ceux désactivés."
 
     # ressource already exists
     if resource_id is not None:
@@ -262,7 +375,7 @@ def data_gouv_create_resource(
     return True
 
 
-def data_gouv_resource_id(dataset_id, area):
+def data_gouv_resource_id(dataset_id, area, only_active: bool):
     # get the resource id from data.gouv.fr
     DATA_GOUV_BASE_URL = os.environ.get("DATA_GOUV_BASE_URL")
     dataset_url = f"{DATA_GOUV_BASE_URL}/api/1/datasets/{dataset_id}/"
@@ -274,14 +387,9 @@ def data_gouv_resource_id(dataset_id, area):
     else:
         res = response.json()
         resources = res["resources"]
+        title = resource_title(area, only_active)
         for resource in resources:
-            if resource["format"] == "zip" and (
-                (area == "nat" and resource["title"] == "Export National")
-                or (
-                    area != "nat"
-                    and resource["title"] == f"Export Départemental {area}"
-                )
-            ):
+            if resource["format"] == "zip" and resource["title"] == title:
                 return resource["id"]
         return None
 

--- a/app/batid/tests/test_data_gouv_publication.py
+++ b/app/batid/tests/test_data_gouv_publication.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import boto3
 from batid.models import Address, Building, Department_subdivided, Plot
+from batid.models.others import UserProfile
 from batid.services.data_gouv_publication import (
     cleanup_directory,
     create_archive,
@@ -17,8 +18,9 @@ from batid.services.data_gouv_publication import (
     update_resource_metadata,
     upload_to_s3,
 )
+from django.contrib.auth.models import User
 from django.contrib.gis.geos import GEOSGeometry
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from freezegun import freeze_time
 from moto import mock_aws
 
@@ -100,6 +102,11 @@ def get_resources():
             {"id": "2", "title": "Export Départemental 33", "format": "zip"},
             {"id": "3", "title": "Export Départemental 75", "format": "zip"},
             {"id": "4", "title": "Export National", "format": "zip"},
+            {
+                "id": "5",
+                "title": "Export National (avec historique)",
+                "format": "zip",
+            },
         ]
     }
     return json
@@ -219,9 +226,9 @@ class TestDataGouvPublication(TestCase):
         )
 
         area = "75"
-        directory_name = create_directory(area)
+        directory_name = create_directory(area, True)
 
-        create_csv(directory_name, area)
+        create_csv(directory_name, area, True)
 
         # Check if the directory exists
         self.assertTrue(os.path.exists(directory_name))
@@ -322,7 +329,9 @@ class TestDataGouvPublication(TestCase):
             # Finally, check the content of the rows
             self.assertListEqual(rows, expected_rows)
 
-        archive_path, archive_size, archive_sha1 = create_archive(directory_name, area)
+        archive_path, archive_size, archive_sha1 = create_archive(
+            directory_name, area, True
+        )
 
         # check the archive exists
         self.assertTrue(os.path.exists(archive_path))
@@ -356,11 +365,13 @@ class TestDataGouvPublication(TestCase):
             ext_ids={"some_source": "1234"},
         )
         area = "nat"
-        directory_name = create_directory(area)
+        directory_name = create_directory(area, True)
 
-        create_csv(directory_name, area)
+        create_csv(directory_name, area, True)
 
-        archive_path, archive_size, archive_sha1 = create_archive(directory_name, area)
+        archive_path, archive_size, archive_sha1 = create_archive(
+            directory_name, area, True
+        )
 
         # create the mock s3 bucket
         conn = boto3.resource("s3")
@@ -383,16 +394,26 @@ class TestDataGouvPublication(TestCase):
         get_mock.return_value.status_code = 200
         get_mock.return_value.json.return_value = get_resources()
 
-        resource_id = data_gouv_resource_id("some-dataset-id", "33")
+        resource_id = data_gouv_resource_id("some-dataset-id", "33", True)
         self.assertEqual(resource_id, "2")
 
-        resource_id = data_gouv_resource_id("some-dataset-id", "75")
+        resource_id = data_gouv_resource_id("some-dataset-id", "75", True)
         self.assertEqual(resource_id, "3")
 
-        resource_id = data_gouv_resource_id("some-dataset-id", "nat")
+        resource_id = data_gouv_resource_id("some-dataset-id", "nat", True)
         self.assertEqual(resource_id, "4")
 
-        resource_id = data_gouv_resource_id("some-dataset-id", "123")
+        resource_id = data_gouv_resource_id("some-dataset-id", "123", True)
+        self.assertIsNone(resource_id)
+
+        # the "with history" (full) export must match the historical resource,
+        # not the active one with the same base title
+        resource_id = data_gouv_resource_id("some-dataset-id", "nat", False)
+        self.assertEqual(resource_id, "5")
+
+        # no historical resource exists for dept 75, so the full export must not
+        # fall back on the active resource (id "3")
+        resource_id = data_gouv_resource_id("some-dataset-id", "75", False)
         self.assertIsNone(resource_id)
 
     @freeze_time("2021-02-23")
@@ -510,7 +531,9 @@ class TestDataGouvPublication(TestCase):
         archive_size = 1234
         archive_sha1 = "some-sha1"
         format = "csv"
-        publish_on_data_gouv(department, public_url, archive_size, archive_sha1, format)
+        publish_on_data_gouv(
+            department, True, public_url, archive_size, archive_sha1, format
+        )
 
         put_mock.assert_called_with(
             f"{os.environ.get('DATA_GOUV_BASE_URL')}/api/1/datasets/some-dataset-id/resources/2/",
@@ -557,7 +580,9 @@ class TestDataGouvPublication(TestCase):
         archive_size = 1234
         archive_sha1 = "some-sha1"
         format = "csv"
-        publish_on_data_gouv("nat", public_url, archive_size, archive_sha1, format)
+        publish_on_data_gouv(
+            "nat", True, public_url, archive_size, archive_sha1, format
+        )
 
         put_mock.assert_called_with(
             f"{os.environ.get('DATA_GOUV_BASE_URL')}/api/1/datasets/some-dataset-id/resources/4/",
@@ -604,7 +629,9 @@ class TestDataGouvPublication(TestCase):
         archive_size = 1234
         archive_sha1 = "some-sha1"
         format = "csv"
-        publish_on_data_gouv(department, public_url, archive_size, archive_sha1, format)
+        publish_on_data_gouv(
+            department, True, public_url, archive_size, archive_sha1, format
+        )
 
         post_mock.assert_called_with(
             f"{os.environ.get('DATA_GOUV_BASE_URL')}/api/1/datasets/some-dataset-id/resources/",
@@ -624,3 +651,97 @@ class TestDataGouvPublication(TestCase):
                 "created_at": str(datetime.now()),
             },
         )
+
+    @override_settings(MAX_BUILDING_AREA=float("inf"))
+    def test_full_export_with_history(self):
+        """
+        Input: one building created with address A (and validated by a user),
+        then updated to address B with a new status. This produces one
+        historical version (address A) and one current version (address B) in
+        the batid_building_with_history view.
+
+        Expected: the "full" export (only_active=False) contains two rows for
+        the same rnb_id; each row carries the textual address it had at the
+        time (A for the historical row, B for the current one) next to its
+        interop key; internal user ids are resolved to usernames (event_user
+        and validated_by); and the history-only columns (is_active, sys_period,
+        event_type) are present.
+        """
+        user = User.objects.create_user(
+            username="contributor", email="contributor@example.test"
+        )
+        UserProfile.objects.create(user=user)
+
+        geom = get_geom_paris()
+
+        address_a = Address.objects.create(
+            id="ADDR_A",
+            source="BAN",
+            street_number="4",
+            street="rue scipion",
+            city_name="Paris",
+            city_zipcode="75005",
+        )
+        address_b = Address.objects.create(
+            id="ADDR_B",
+            source="BAN",
+            street_number="6",
+            street="rue hello",
+            city_name="Paris",
+            city_zipcode="75020",
+        )
+
+        building = Building.create_new(
+            user=user,
+            event_origin={"source": "contribution"},
+            status="constructed",
+            addresses_id=[address_a.id],
+            shape=geom,
+            ext_ids=[],
+            is_valid=True,
+        )
+        # generates a historical version (address A) and a new current version
+        building.update(
+            user=user,
+            event_origin={"source": "contribution"},
+            status="demolished",
+            addresses_id=[address_b.id],
+        )
+
+        area = "nat"
+        directory_name = create_directory(area, False)
+        create_csv(directory_name, area, False)
+
+        with open(f"{directory_name}/RNB_{area}_full.csv", "r") as f:
+            reader = csv.DictReader(f, delimiter=";")
+            fieldnames = reader.fieldnames
+            rows = list(reader)
+
+        cleanup_directory(directory_name)
+
+        # both versions of the same building are exported
+        self.assertEqual(len(rows), 2)
+        self.assertTrue(all(row["rnb_id"] == building.rnb_id for row in rows))
+
+        # history-only columns are part of the full export
+        for column in ["is_active", "sys_period", "event_type", "event_user"]:
+            self.assertIn(column, fieldnames)
+
+        # both versions are still active (an update does not deactivate); they
+        # are told apart by their event_type
+        current = next(row for row in rows if row["event_type"] == "update")
+        historical = next(row for row in rows if row["event_type"] == "creation")
+
+        # each version carries the textual address it had at the time,
+        # rebuilt from the historized addresses_id (not the readonly table)
+        current_addresses = json.loads(current["addresses"])
+        historical_addresses = json.loads(historical["addresses"])
+        self.assertEqual(current_addresses[0]["cle_interop_ban"], "ADDR_B")
+        self.assertEqual(current_addresses[0]["street"], "rue hello")
+        self.assertEqual(historical_addresses[0]["cle_interop_ban"], "ADDR_A")
+        self.assertEqual(historical_addresses[0]["street"], "rue scipion")
+
+        # internal user ids are resolved to usernames
+        self.assertEqual(current["event_user"], "contributor")
+        # the building was validated at creation, before the update reset it
+        self.assertEqual(historical["validated_by"], "{contributor}")


### PR DESCRIPTION
Suite à la discussion avec le CSTB, j'adapte la tâche de publication des donnée sur data.gouv pour inclure les lignes historisées et inactives. Cette version comprend toutes les colonnes de la table building pour permettre à l'utilisateur d'avoir toutes les infos sous la main. Les id des utilisateurs sont remplacés par leurs usernames.

Je n'ai pas testé que la requête passait en terme de perf. J'hésite à la lancer à la main pour voir ce que ça donne.