### PR TITLE
Retrait du prénom et du nom

### DIFF
--- a/app/api_alpha/serializers/public_user.py
+++ b/app/api_alpha/serializers/public_user.py
@@ -21,15 +21,3 @@ class PublicUserSerializer(serializers.Serializer):
             return None
 
         return instance.profile.organization
-
-    def _get_display_name(self, instance: User | None) -> str:
-        if instance is None:
-            return "Anonyme"
-
-        if not instance.first_name and not instance.last_name:
-            return instance.username
-
-        if instance.last_name is None or len(instance.last_name) == 0:
-            return instance.first_name
-
-        return f"{instance.first_name} {instance.last_name[0]}."

--- a/app/api_alpha/tests/reports/test_create_report.py
+++ b/app/api_alpha/tests/reports/test_create_report.py
@@ -72,7 +72,7 @@ class CreateReportTest(APITestCase):
         response_data = response.json()
         self.assertEqual(response_data["rnb_id"], "TEST00000001")
         self.assertEqual(response_data["status"], "pending")
-        self.assertEqual(response_data["author"]["display_name"], "Test U.")
+        self.assertEqual(response_data["author"]["display_name"], "testuser")
         self.assertEqual(response_data["author"]["username"], "testuser")
 
         # Verify the report was created with the authenticated user

--- a/app/api_alpha/tests/reports/test_get_report.py
+++ b/app/api_alpha/tests/reports/test_get_report.py
@@ -60,7 +60,7 @@ class GetReportTest(APITestCase):
         self.assertEqual(data["point"]["coordinates"], [2.3522, 48.8566])
 
         author = data["author"]
-        self.assertEqual(author["display_name"], "Test U.")
+        self.assertEqual(author["display_name"], "testuser")
         self.assertCountEqual(data["tags"], ["tag1", "tag2"])
 
         self.assertEqual(len(data["messages"]), 2)

--- a/app/api_alpha/tests/test_history.py
+++ b/app/api_alpha/tests/test_history.py
@@ -157,8 +157,7 @@ class SingleBuildingHistoryTest(APITestCase):
                     "details": None,
                     "author": {
                         "id": self.user_id,
-                        "first_name": "Julie",
-                        "last_name": "S.",
+                        "display_name": "ju_sig",
                         "organization_name": "Mairie de Dreux",
                         "organization_short_name": "Dreux",
                         "username": "ju_sig",
@@ -658,7 +657,7 @@ class SingleBuildingHistoryTest(APITestCase):
             data[0]["validated_by"],
             [
                 {
-                    "display_name": "Julie S.",
+                    "display_name": "ju_sig",
                     "id": self.user_id,
                     "organization_name": "Mairie de Dreux",
                     "organization_short_name": "Dreux",

--- a/app/api_alpha/utils/rnb_doc.py
+++ b/app/api_alpha/utils/rnb_doc.py
@@ -261,8 +261,8 @@ def _get_components() -> dict:
                     "username": {"type": "string", "example": "n.martin"},
                     "display_name": {
                         "type": "string",
-                        "description": "Nom à afficher pour l'utilisateur. Il peut s'agir du nom d'utilisateur ou d'un nom plus complet si celui-ci a été renseigné par l'utilisateur.",
-                        "example": "Nicolas Martin",
+                        "description": "Nom à afficher pour l'utilisateur. Il s'agit de son nom d'utilisateur.",
+                        "example": "n.martin",
                     },
                     "organization_name": {
                         "type": "string",

--- a/app/batid/services/bdg_history.py
+++ b/app/batid/services/bdg_history.py
@@ -39,12 +39,8 @@ def get_bdg_history(rnb_id: str) -> list[dict]:
             json_build_object(
                 'id', mu.id,
                 'username', mu.username,
-                'display_name',
-                case
-                    when mu.last_name is not null and mu.last_name <> ''
-                    then mu.first_name || ' ' || substring(mu.last_name, 1, 1) || '.'
-                    else mu.first_name
-                end,
+                -- We deliberately no longer expose first/last name: display_name is the username
+                'display_name', mu.username,
                 'organization_name', mu_org.name,
                 'organization_short_name', mu_org.short_name
             )
@@ -78,12 +74,8 @@ def get_bdg_history(rnb_id: str) -> list[dict]:
 	    	then json_build_object(
     			'id', u.id,
                 'username', u.username,
-    			'first_name', u.first_name,
-    			'last_name',
-	    		case
-	    			when u.last_name is not null and u.last_name <> ''
-	    			then substring(u.last_name, 1, 1) || '.' else null
-	    		end,
+                -- We deliberately no longer expose first/last name: display_name is the username
+    			'display_name', u.username,
 	    		'organization_name', author_org.name,
 	    		'organization_short_name', author_org.short_name
 	    	) else null

--- a/app/batid/services/user.py
+++ b/app/batid/services/user.py
@@ -42,13 +42,8 @@ def _b64_to_int(b64: str) -> int:
 
 
 def get_display_name(user: User | None) -> str:
+
     if user is None:
         return "Anonyme"
 
-    if not user.first_name and not user.last_name:
-        return user.username
-
-    if user.last_name is None or len(user.last_name) == 0:
-        return user.first_name
-
-    return f"{user.first_name} {user.last_name[0]}."
+    return user.username


### PR DESCRIPTION
On ne distribue plus le prénom et le nom de l'utilisateur. C'est une donnée privée et nous ne sommes pas au clair sur les règles concernant leur affichage.