### PR TITLE
Ajoute l'organisation de l'auteur dans le diff

### DIFF
--- a/app/api_alpha/endpoints/buildings/get_diff.py
+++ b/app/api_alpha/endpoints/buildings/get_diff.py
@@ -69,7 +69,7 @@ class DiffView(RNBLoggingMixin, APIView):
                             "text/csv": {
                                 "schema": {"type": "string"},
                                 "example": (
-                                    "action,rnb_id,status,is_active,sys_period,point,shape,addresses_id,ext_ids,parent_buildings,event_id,event_type,username,validated_by"
+                                    "action,rnb_id,status,is_active,sys_period,point,shape,addresses_id,ext_ids,parent_buildings,event_id,event_type,username,user_organization_name,user_organization_id,validated_by"
                                 ),
                             }
                         },
@@ -219,6 +219,8 @@ class DiffView(RNBLoggingMixin, APIView):
                             event_id,
                             event_type,
                             COALESCE(u.username, 'RNB') as username,
+                            org.name as user_organization_name,
+                            org.id as user_organization_id,
                             (
                                 SELECT COALESCE(json_agg(
                                     json_build_object(
@@ -240,6 +242,8 @@ class DiffView(RNBLoggingMixin, APIView):
                             ) as validated_by
                             FROM batid_building_with_history bb
                             LEFT JOIN auth_user u on u.id = bb.event_user_id
+                            LEFT JOIN batid_userprofile up ON up.user_id = u.id
+                            LEFT JOIN batid_organization org ON org.id = up.organization_id
                             where lower(sys_period) > {start}::timestamp with time zone and lower(sys_period) <= {end}::timestamp with time zone"""
                         + spatial_filter  # nosec B608: spatial_filter comes from database (City.shape.wkt), not user input, and is escaped via sql.Literal() below
                         + """

--- a/app/api_alpha/tests/buildings/test_diff.py
+++ b/app/api_alpha/tests/buildings/test_diff.py
@@ -36,6 +36,13 @@ class DiffTest(TransactionTestCase):
         Address.objects.create(id="ADDRESS_ID_3")
 
     def test_diff_create_update_deactivate(self):
+        """
+        Input: three buildings, some created/deactivated by 'marcella' (who belongs to
+        the 'Mairie Marseille' organization), some created without any author.
+        Expected: the diff CSV exposes the full column list; rows authored by marcella
+        carry her organization name and id, rows without an author (username='RNB')
+        leave both organization columns empty.
+        """
 
         # Get the user
         user = User.objects.get(username="marcella")
@@ -132,6 +139,8 @@ class DiffTest(TransactionTestCase):
                 "event_id",
                 "event_type",
                 "username",
+                "user_organization_name",
+                "user_organization_id",
                 "validated_by",
             ],
         )
@@ -160,6 +169,9 @@ class DiffTest(TransactionTestCase):
             json.loads(rows[0]["addresses_id"]), ["ADDRESS_ID_2", "ADDRESS_ID_3"]
         )
         self.assertEqual(rows[0]["username"], "marcella")
+        org = Organization.objects.get(name="Mairie Marseille")
+        self.assertEqual(rows[0]["user_organization_name"], "Mairie Marseille")
+        self.assertEqual(rows[0]["user_organization_id"], str(org.id))
 
         self.assertEqual(rows[1]["action"], "create")
         self.assertEqual(rows[1]["rnb_id"], b2.rnb_id)
@@ -167,6 +179,9 @@ class DiffTest(TransactionTestCase):
         self.assertRegex(rows[1]["point"], r"SRID=4326;POINT\(\d+\.\d+ \d+\.\d+\)")
         self.assertRegex(rows[1]["shape"], r"SRID=4326;MULTIPOLYGON\(.+\)")
         self.assertEqual(rows[1]["username"], "RNB")
+        # automatic modification: no author, hence no organization
+        self.assertEqual(rows[1]["user_organization_name"], "")
+        self.assertEqual(rows[1]["user_organization_id"], "")
         self.assertEqual(json.loads(rows[1]["validated_by"]), [])
 
         self.assertEqual(rows[2]["action"], "create")
@@ -178,6 +193,8 @@ class DiffTest(TransactionTestCase):
         self.assertEqual(rows[3]["rnb_id"], b3.rnb_id)
         self.assertEqual(rows[3]["status"], "constructed")
         self.assertEqual(rows[3]["username"], "marcella")
+        self.assertEqual(rows[3]["user_organization_name"], "Mairie Marseille")
+        self.assertEqual(rows[3]["user_organization_id"], str(org.id))
 
         # check the CSV file name
         b3 = Building.objects.get(rnb_id="3")
@@ -188,6 +205,52 @@ class DiffTest(TransactionTestCase):
         self.assertEqual(
             r["Content-Disposition"], f'attachment; filename="{expected_name}"'
         )
+
+    def test_diff_user_without_organization(self):
+        """
+        Input: two buildings created by users with no organization — one whose
+        UserProfile has a null organization, one with no UserProfile at all.
+        Expected: both rows report the username but leave the two organization
+        columns empty.
+        """
+        no_profile_user = User.objects.create_user(
+            username="jeanne", email="jeanne@example.com"
+        )
+        no_org_user = User.objects.create_user(
+            username="ahmed", email="ahmed@example.com"
+        )
+        UserProfile.objects.create(user=no_org_user)
+
+        Building.objects.create(rnb_id="t", event_type="creation")
+        threshold = Building.objects.get(rnb_id="t").sys_period.lower
+
+        Building.objects.create(
+            rnb_id="1",
+            status="constructed",
+            event_type="creation",
+            event_user=no_profile_user,
+        )
+        Building.objects.create(
+            rnb_id="2",
+            status="constructed",
+            event_type="creation",
+            event_user=no_org_user,
+        )
+
+        params = urlencode({"since": threshold.isoformat()})
+        r = self.client.get(f"/api/alpha/buildings/diff/?{params}")
+
+        self.assertEqual(r.status_code, 200)
+
+        diff_text = get_content_from_streaming_response(r)
+        rows = list(csv.DictReader(io.StringIO(diff_text)))
+
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["username"], "jeanne")
+        self.assertEqual(rows[1]["username"], "ahmed")
+        for row in rows:
+            self.assertEqual(row["user_organization_name"], "")
+            self.assertEqual(row["user_organization_id"], "")
 
     def test_diff_merge(self):
 


### PR DESCRIPTION
Ajoute deux colonnes au CSV du endpoint `/buildings/diff/` : `user_organization_name` et `user_organization_id`, insérées entre `username` et `validated_by`.

## Sémantique

- Il s'agit de l'organisation de **l'auteur de l'événement** (`event_user_id`), celui de la colonne `username`. Le JSON `validated_by`, qui porte déjà des infos d'organisation, n'est pas modifié.
- `user_organization_id` est la clé primaire de `batid_organization`.
- Les deux colonnes sont **vides** quand il n'y a pas d'organisation à reporter : modification automatique (`username` = `RNB`) ou utilisateur sans profil / sans organisation.
- L'organisation reportée est le rattachement **courant** de l'utilisateur, pas celui qu'il avait au moment de la modification — `batid_userprofile` n'est pas historisé. C'est déjà le comportement de `validated_by`.

## Implémentation

Deux `LEFT JOIN` (`batid_userprofile` puis `batid_organization`), reprenant l'idiome déjà utilisé dans `data_gouv_publication.py`. `UserProfile` étant en OneToOne avec `User`, aucun risque de multiplication de lignes. Pas de migration.

L'exemple d'en-tête CSV de la doc OpenAPI est mis à jour.

## Tests

- Liste des colonnes attendues complétée.
- Assertions ajoutées sur les lignes avec auteur (organisation renseignée) et sans auteur (colonnes vides).
- Nouveau test `test_diff_user_without_organization` pour le cas jusqu'ici non couvert : utilisateur avec un `UserProfile` sans organisation, et utilisateur sans `UserProfile`.

`api_alpha.tests.buildings.test_diff` (20 tests) et `batid.tests.test_validated_by_format` (6 tests) passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)