### PR TITLE
Refuse les géométries 3D avec une erreur 400

### DIFF
--- a/app/api_alpha/endpoints/buildings/single_building.py
+++ b/app/api_alpha/endpoints/buildings/single_building.py
@@ -226,7 +226,7 @@ Si ce paramêtre est :
                                     },
                                     "shape": {
                                         "type": "string",
-                                        "description": """Géométrie du bâtiment au format WKT ou HEX, en WGS84. La géometrie attendue est idéalement un polygone représentant le bâtiment, mais il est également possible de ne donner qu'un point.""",
+                                        "description": """Géométrie du bâtiment au format WKT ou HEX, en WGS84. La géometrie attendue est idéalement un polygone représentant le bâtiment, mais il est également possible de ne donner qu'un point. La géométrie doit être en 2D : les géométries 3D (avec une coordonnée Z) sont refusées.""",
                                     },
                                     "is_valid": {
                                         "type": "boolean",

--- a/app/api_alpha/tests/buildings/test_update.py
+++ b/app/api_alpha/tests/buildings/test_update.py
@@ -107,6 +107,22 @@ class BuildingPatchTest(APITestCase):
             r.json()["detail"],
         )
 
+    def test_update_a_building_3d_shape(self):
+        """PATCH with a 3D shape (WKT with Z coordinates, as exported by some GIS)
+        answers 400 with an explicit message, instead of crashing with a 500."""
+        data = {
+            "shape": "POLYGON Z ((0 0 10, 0 1 10, 1 1 10, 1 0 10, 0 0 10))",
+        }
+
+        r = self.client.patch(
+            f"/api/alpha/buildings/{self.rnb_id}/",
+            data=json.dumps(data),
+            content_type="application/json",
+        )
+
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("3D", r.json()["detail"])
+
     def test_update_a_building_parameters(self):
         # empty data
         data = {}

--- a/app/batid/tests/test_geo.py
+++ b/app/batid/tests/test_geo.py
@@ -224,6 +224,32 @@ class TestShapeVerification(TestCase):
         )
         self.assertTrue(assert_shape_is_valid(shape))
 
+    def test_3d_polygon_is_rejected(self):
+        """A polygon with Z coordinates is refused with an explicit 3D message
+        (the RNB only stores 2D shapes), instead of crashing."""
+        shape = GEOSGeometry(
+            "POLYGON Z ((-0.5951753764650443 44.8 10, -0.5951753764650443 44.80001 10, -0.5951 44.80001 10, -0.5951 44.8 10, -0.5951753764650443 44.8 10))"
+        )
+
+        with self.assertRaises(InvalidWGS84Geometry) as ctx:
+            assert_shape_is_valid(shape)
+
+        self.assertIn("3D", str(ctx.exception))
+
+    def test_3d_point_is_rejected(self):
+        """A point with a Z coordinate is refused with an InvalidWGS84Geometry error."""
+        shape = GEOSGeometry("POINT Z (25 12 3)")
+
+        with self.assertRaises(InvalidWGS84Geometry):
+            assert_shape_is_valid(shape)
+
+    def test_3d_multipolygon_is_rejected(self):
+        """A multipolygon with Z coordinates is refused with an InvalidWGS84Geometry error."""
+        shape = GEOSGeometry("MULTIPOLYGON Z (((0 0 1, 0 1 1, 1 1 1, 1 0 1, 0 0 1)))")
+
+        with self.assertRaises(InvalidWGS84Geometry):
+            assert_shape_is_valid(shape)
+
     def test_invalid_geometry(self):
         # a butterfly shape (self intersection)
         shape = GEOSGeometry("POLYGON ((0 0, 1 0, 0 1 , 1 1, 0 0))")

--- a/app/batid/utils/geo.py
+++ b/app/batid/utils/geo.py
@@ -128,6 +128,13 @@ def assert_shape_is_valid(geom: GEOSGeometry):
     if not geom.valid:
         raise InvalidWGS84Geometry()
 
+    # The RNB only stores 2D shapes: the geometry columns reject a Z dimension.
+    # We refuse 3D geometries explicitly rather than letting them fail later on.
+    if geom.hasz:
+        raise InvalidWGS84Geometry(
+            "Les géométries 3D ne sont pas supportées, veuillez fournir une géométrie 2D"
+        )
+
     def check_simple_tuple(t):
         lon, lat = t
         if not (-180 <= lon <= 180):


### PR DESCRIPTION
## Problème

Sentry [RNB-COEUR-MD](https://sentry.incubateur.net/organizations/betagouv/issues/299521/) : 63 `TypeError: 'float' object is not iterable` (500) sur `PATCH /api/alpha/buildings/{rnb_id}/`.

Marc, de Bordeaux Métropole a envoyé une géométrie 3D (WKT avec coordonnées Z). Chaque coordonnée est alors un tuple de 3 éléments, que `check_coords` (`batid/utils/geo.py`) prend pour un niveau d'imbrication supplémentaire : il recurse jusqu'à itérer sur un float.

## Correctif

Accepter les tuples de 3 n'aurait pas suffi : les colonnes `geometry(Geometry,4326)` et `geometry(Point,4326)` refusent la dimension Z (`Geometry has Z dimension but column does not`), la sauvegarde aurait échoué juste après.

Le RNB ne stocke que de la 2D : on refuse donc en amont dans `assert_shape_is_valid`, avec un message explicite. L'exception `InvalidWGS84Geometry` est déjà traduite en **400** par les endpoints, et le correctif couvre tous les appelants (mise à jour, création, fusion, division, ainsi que l'inspection des candidats, qui refuse proprement le candidat au lieu de planter).

La contrainte 2D est documentée dans la description OpenAPI du champ `shape`.

## Tests

4 nouveaux tests, rouges avant le correctif avec l'erreur de production :
- `batid/tests/test_geo.py` : polygone, point et multipolygone 3D
- `api_alpha/tests/buildings/test_update.py` : `PATCH` avec une forme 3D → 400 + message

90 tests de `test_geo`, `test_update`, `test_creation`, `test_merge`, `test_split` et `test_schema` : OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)