### PR TITLE
Vacuum et analyze de batid_candidate avant l'inspection

### DIFF
--- a/app/batid/services/candidate.py
+++ b/app/batid/services/candidate.py
@@ -1,5 +1,6 @@
+import logging
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Literal
 
 from batid.exceptions import BuildingTooLarge, BuildingTooSmall, InvalidWGS84Geometry
@@ -362,6 +363,56 @@ def create_building_from_candidate(c: Candidate) -> Building:
     )
 
     return b
+
+
+MAINTENANCE_STALE_AFTER = timedelta(days=30)
+
+
+def vacuum_analyze_candidates_if_needed():
+    """Run VACUUM ANALYZE on the candidate table if its vacuum or analyze is stale.
+
+    Fails open: inspection must proceed even if this maintenance step fails.
+    """
+    try:
+        if _candidate_maintenance_is_stale():
+            with connection.cursor() as cursor:
+                cursor.execute("SET statement_timeout = '0';")
+                cursor.execute(f"VACUUM ANALYZE {Candidate._meta.db_table};")
+                cursor.execute("RESET statement_timeout;")
+    except Exception:
+        logging.exception(
+            "Could not VACUUM ANALYZE the candidate table before inspection"
+        )
+
+
+def _candidate_maintenance_is_stale() -> bool:
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT last_vacuum, last_autovacuum, last_analyze, last_autoanalyze "
+            "FROM pg_stat_user_tables WHERE relname = %s",
+            [Candidate._meta.db_table],
+        )
+        row = cursor.fetchone()
+
+    if row is None:
+        return True
+
+    return _maintenance_timestamps_are_stale(*row, now=datetime.now(timezone.utc))
+
+
+def _maintenance_timestamps_are_stale(
+    last_vacuum, last_autovacuum, last_analyze, last_autoanalyze, now
+) -> bool:
+    cutoff = now - MAINTENANCE_STALE_AFTER
+
+    def is_fresh(*timestamps):
+        known = [t for t in timestamps if t is not None]
+        return bool(known) and max(known) >= cutoff
+
+    return not (
+        is_fresh(last_vacuum, last_autovacuum)
+        and is_fresh(last_analyze, last_autoanalyze)
+    )
 
 
 def create_inspection_tasks() -> list:

--- a/app/batid/tasks.py
+++ b/app/batid/tasks.py
@@ -8,8 +8,7 @@ logger = logging.getLogger(__name__)
 from api_alpha.utils.sandbox_client import SandboxClient
 from batid.services.administrative_areas import dpts_list, slice_dpts
 from batid.services.building import export_city as export_city_job
-from batid.services.candidate import Inspector
-from batid.services.candidate import vacuum_analyze_candidates_if_needed
+from batid.services.candidate import Inspector, vacuum_analyze_candidates_if_needed
 from batid.services.data_fix.fill_empty_event_origin import (
     fix as fix_fill_empty_event_origin,
 )

--- a/app/batid/tasks.py
+++ b/app/batid/tasks.py
@@ -9,6 +9,7 @@ from api_alpha.utils.sandbox_client import SandboxClient
 from batid.services.administrative_areas import dpts_list, slice_dpts
 from batid.services.building import export_city as export_city_job
 from batid.services.candidate import Inspector
+from batid.services.candidate import vacuum_analyze_candidates_if_needed
 from batid.services.data_fix.fill_empty_event_origin import (
     fix as fix_fill_empty_event_origin,
 )
@@ -201,6 +202,7 @@ def import_dpts():
 
 @shared_task(autoretry_for=(Exception,), retry_kwargs={"max_retries": 3})
 def inspect_candidates():
+    vacuum_analyze_candidates_if_needed()
     i = Inspector()
     i.inspect()
 

--- a/app/batid/tests/test_candidate_maintenance.py
+++ b/app/batid/tests/test_candidate_maintenance.py
@@ -1,0 +1,95 @@
+import logging
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from unittest import mock
+
+from django.test import SimpleTestCase
+from django.test import TransactionTestCase
+
+from batid.services.candidate import _maintenance_timestamps_are_stale
+from batid.services.candidate import vacuum_analyze_candidates_if_needed
+
+NOW = datetime(2026, 7, 30, tzinfo=timezone.utc)
+FRESH = NOW - timedelta(days=1)
+OLD = NOW - timedelta(days=60)
+
+
+class MaintenanceTimestampsAreStaleTestCase(SimpleTestCase):
+    def test_never_maintained_is_stale(self):
+        """Input: all four pg_stat timestamps are None (table never vacuumed nor analyzed). Expected: stale."""
+        self.assertTrue(
+            _maintenance_timestamps_are_stale(None, None, None, None, now=NOW)
+        )
+
+    def test_fresh_manual_vacuum_and_analyze_is_not_stale(self):
+        """Input: manual vacuum and analyze 1 day ago, no auto maintenance. Expected: not stale."""
+        self.assertFalse(
+            _maintenance_timestamps_are_stale(FRESH, None, FRESH, None, now=NOW)
+        )
+
+    def test_fresh_autovacuum_and_autoanalyze_is_not_stale(self):
+        """Input: autovacuum and autoanalyze 1 day ago, no manual maintenance. Expected: not stale."""
+        self.assertFalse(
+            _maintenance_timestamps_are_stale(None, FRESH, None, FRESH, now=NOW)
+        )
+
+    def test_old_vacuum_with_fresh_analyze_is_stale(self):
+        """Input: last vacuum 60 days ago but analyze 1 day ago. Expected: stale (vacuum overdue)."""
+        self.assertTrue(
+            _maintenance_timestamps_are_stale(OLD, None, FRESH, None, now=NOW)
+        )
+
+    def test_fresh_vacuum_with_old_analyze_is_stale(self):
+        """Input: last vacuum 1 day ago but analyze 60 days ago. Expected: stale (analyze overdue)."""
+        self.assertTrue(
+            _maintenance_timestamps_are_stale(FRESH, None, OLD, None, now=NOW)
+        )
+
+
+class VacuumAnalyzeCandidatesIfNeededTestCase(TransactionTestCase):
+    def test_vacuum_analyze_runs_when_stale(self):
+        """Input: staleness check reports stale. Expected: VACUUM ANALYZE runs against the real database without logging any error."""
+        with mock.patch(
+            "batid.services.candidate._candidate_maintenance_is_stale",
+            return_value=True,
+        ):
+            with self.assertNoLogs(level=logging.ERROR):
+                vacuum_analyze_candidates_if_needed()
+
+
+class VacuumAnalyzeCandidatesMockedTestCase(SimpleTestCase):
+    def test_nothing_runs_when_fresh(self):
+        """Input: staleness check reports fresh. Expected: no SQL is executed at all."""
+        with mock.patch(
+            "batid.services.candidate._candidate_maintenance_is_stale",
+            return_value=False,
+        ):
+            with mock.patch("batid.services.candidate.connection") as connection:
+                vacuum_analyze_candidates_if_needed()
+                connection.cursor.assert_not_called()
+
+    def test_fails_open_on_error(self):
+        """Input: staleness check raises an exception. Expected: no exception propagates, the error is logged."""
+        with mock.patch(
+            "batid.services.candidate._candidate_maintenance_is_stale",
+            side_effect=RuntimeError("boom"),
+        ):
+            with self.assertLogs(level=logging.ERROR):
+                vacuum_analyze_candidates_if_needed()
+
+
+class InspectCandidatesTaskTestCase(SimpleTestCase):
+    def test_maintenance_runs_before_inspection(self):
+        """Input: the inspect_candidates task body. Expected: the vacuum/analyze step is called before Inspector.inspect."""
+        manager = mock.Mock()
+        with mock.patch(
+            "batid.tasks.vacuum_analyze_candidates_if_needed", manager.vacuum
+        ):
+            with mock.patch("batid.tasks.Inspector", manager.Inspector):
+                from batid.tasks import inspect_candidates
+
+                inspect_candidates()
+
+        self.assertEqual(manager.mock_calls[0], mock.call.vacuum())
+        self.assertIn(mock.call.Inspector().inspect(), manager.mock_calls)

--- a/app/batid/tests/test_candidate_maintenance.py
+++ b/app/batid/tests/test_candidate_maintenance.py
@@ -1,14 +1,12 @@
 import logging
-from datetime import datetime
-from datetime import timedelta
-from datetime import timezone
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
-from django.test import SimpleTestCase
-from django.test import TransactionTestCase
-
-from batid.services.candidate import _maintenance_timestamps_are_stale
-from batid.services.candidate import vacuum_analyze_candidates_if_needed
+from batid.services.candidate import (
+    _maintenance_timestamps_are_stale,
+    vacuum_analyze_candidates_if_needed,
+)
+from django.test import SimpleTestCase, TransactionTestCase
 
 NOW = datetime(2026, 7, 30, tzinfo=timezone.utc)
 FRESH = NOW - timedelta(days=1)


### PR DESCRIPTION
Closes #982

## Quoi

Au début de la tâche celery `inspect_candidates`, on vérifie dans `pg_stat_user_tables` les dates des derniers `vacuum`/`autovacuum` et `analyze`/`autoanalyze` de `batid_candidate`. Si l'une des deux opérations date de plus de 30 jours (ou n'a jamais eu lieu), on lance un `VACUUM ANALYZE batid_candidate` avant de démarrer l'inspection, avec le `statement_timeout` levé le temps de l'opération.

## Choix de conception

- **Placement** : au début du corps de la tâche `inspect_candidates`, pour que la maintenance précède l'inspection quel que soit le mode de lancement (commande, retry, chaînage futur).
- **Périmètre** : `batid_candidate` uniquement — c'est le correctif mesuré lors du dernier import (cf. commentaire de l'issue) ; `batid_building` est volontairement exclu.
- **Fail open** : toute erreur sur l'étape de maintenance est loggée et l'inspection démarre quand même — une inspection lente vaut mieux que pas d'inspection (et ça évite que l'`autoretry` de la tâche bloque sur un souci de vacuum).
- **Pas de garde-fou de concurrence** : un vacuum redondant entre deux workers simultanés est inoffensif, et le cas ne se produit pas aujourd'hui.

## Risque résiduel accepté

Le seuil basé sur les timestamps (30 jours) **ne déclenchera pas** de vacuum si un import massif arrive juste après un autovacuum : les stats paraissent fraîches alors qu'elles ne décrivent plus la table. Si l'inspection est encore lente au prochain import BD Topo, c'est la condition qu'il faudra revisiter (par ex. passer sur `n_mod_since_analyze`), pas le placement.

## Tests

`batid.tests.test_candidate_maintenance` : 9 tests — logique de fraîcheur (jamais maintenu, manuel frais, auto frais, une des deux opérations périmée), skip quand frais, fail open, exécution réelle du `VACUUM ANALYZE` sur la base de test, et ordre maintenance → inspection dans la tâche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)