### PR TITLE
Corrige la fuite de processus de l'endpoint diff

### DIFF
--- a/app/api_alpha/endpoints/buildings/get_diff.py
+++ b/app/api_alpha/endpoints/buildings/get_diff.py
@@ -1,5 +1,6 @@
 import os
 import re
+import traceback
 from datetime import datetime, timedelta, timezone
 
 from api_alpha.utils.logging_mixin import RNBLoggingMixin
@@ -136,38 +137,103 @@ class DiffView(RNBLoggingMixin, APIView):
             cursor.execute(most_recent_modification_query)
             most_recent_modification = cursor.fetchone()[0]
 
+        # The export can take a long time, and we want the client to start
+        # receiving data right away instead of waiting for the whole file. So a
+        # separate process runs the export and writes into a pipe, while the web
+        # server reads from that pipe and sends the result to the client.
+        # Could we keep this streaming without a separate process?
+        # https://stackoverflow.com/questions/78998534/stream-data-from-postgres-to-http-request-using-django-streaminghttpresponse?noredirect=1#comment139290268_78998534
+        #
         # file descriptors r, w for reading and writing
         rfd, wfd = os.pipe()
-        # the process is forked
-        # would it be possible to avoid creating a new process
-        # and keep the streaming feature?
-        # https://stackoverflow.com/questions/78998534/stream-data-from-postgres-to-http-request-using-django-streaminghttpresponse?noredirect=1#comment139290268_78998534
-        processid = os.fork()
 
-        if processid:
-            # This is the parent process
-            # the parent will only read data coming from the child process, we can close w
+        # We create that separate process in two steps, and this needs an
+        # explanation.
+        #
+        # The problem: a process that has finished does not disappear by itself.
+        # Its parent has to collect its exit code, otherwise the finished process
+        # stays in the system's list and keeps using one of the limited number of
+        # process slots. The web server (gunicorn) never collects the exit code
+        # of processes we create ourselves, so a single process per request would
+        # mean one leftover process per download, forever. Once the slots run
+        # out, creating any process fails and this endpoint stays broken until
+        # the container is restarted.
+        #
+        # The solution: create a short-lived middle process whose only job is to
+        # create the process doing the real work, then stop immediately. We
+        # collect the exit code of that middle process straight away, which costs
+        # us nothing since it stops at once. The export process is then left with
+        # no parent, and the system automatically hands it over to the very first
+        # process of the container, which does collect exit codes. So nothing
+        # piles up.
+        try:
+            middle_pid = os.fork()
+        except OSError:
+            # Close both ends of the pipe, otherwise the file descriptors stay
+            # open for the lifetime of the web server and leak on every failure.
+            os.close(rfd)
             os.close(wfd)
-            # data coming from the child process arrives here
-            r = os.fdopen(rfd)
-            if insee_code:
-                filename = f"diff_{insee_code}_{since.isoformat()}_{most_recent_modification.isoformat()}.csv"
-            else:
-                filename = f"diff_{since.isoformat()}_{most_recent_modification.isoformat()}.csv"
+            raise
+
+        if middle_pid:
+            # This is the web server process.
+            # It will only read the exported data, we can close w
+            os.close(wfd)
+            # The middle process stops as soon as it has created the export
+            # process, so this wait is very short.
+            _, status = os.waitpid(middle_pid, 0)
+            if status != 0:
+                # The middle process could not create the export process, so
+                # nobody will ever write into the pipe.
+                os.close(rfd)
+                return HttpResponse(
+                    "The server is temporarily out of resources, please try again later.",
+                    status=503,
+                )
+            try:
+                if insee_code:
+                    filename = f"diff_{insee_code}_{since.isoformat()}_{most_recent_modification.isoformat()}.csv"
+                else:
+                    filename = f"diff_{since.isoformat()}_{most_recent_modification.isoformat()}.csv"
+                # data coming from the export process arrives here
+                r = os.fdopen(rfd)
+            except BaseException:
+                # We failed to build the response, so nobody will read the pipe.
+                # Closing our end makes the export process stop instead of
+                # waiting forever for someone to read what it writes.
+                os.close(rfd)
+                raise
             return StreamingHttpResponse(
                 r,
                 content_type="text/csv",
                 headers={"Content-Disposition": f'attachment; filename="{filename}"'},
             )
-        else:
-            # This is the child process
-            # the child will only write data, we can close r
-            os.close(rfd)
-            w = os.fdopen(wfd, "w")
 
+        # This is the middle process. It creates the export process and stops
+        # right away so the web server process does not have to wait for it.
+        try:
+            if os.fork():
+                os._exit(0)
+        except OSError:
+            # Tell the web server process we could not create the export process.
+            os._exit(1)
+
+        # This is the export process.
+        # It will only write data, we can close r
+        os.close(rfd)
+        w = os.fdopen(wfd, "w")
+
+        # Everything below is wrapped, and this process always ends by calling
+        # os._exit(). That is not optional: this process is a copy of the web
+        # server and it inherited the network socket the server listens on. If an
+        # error escaped from here, the copy would go back into the web server
+        # code and start answering requests in parallel with the real server,
+        # while never stopping. This happens as soon as a client cancels a
+        # download, which is a perfectly normal thing for a client to do.
+        try:
             # Abandon the inherited database connection without closing it
-            # (the parent process still needs it). Setting connection to None
-            # forces Django to create a new connection for this child process.
+            # (the web server process still needs it). Setting connection to None
+            # forces Django to create a new connection for this process.
             connection.connection = None
 
             with connection.cursor() as cursor:
@@ -272,6 +338,27 @@ class DiffView(RNBLoggingMixin, APIView):
                     cursor.copy_expert(sql_query, w)
                     start_ts = end_ts
             connection.close()
+            # Closing w sends the data still held in memory, so the client gets
+            # the end of the file.
             w.close()
-            # the child process is terminated
+        except BrokenPipeError:
+            # The client closed the connection before the end of the download,
+            # for instance because they cancelled it. Nothing went wrong on our
+            # side, there is simply nobody left to send the data to.
+            pass
+        except BaseException:
+            # We report the problem by writing on the error output, which the
+            # container collects in its logs. We do not use the usual error
+            # reporting tools here: this process is a copy taken while the web
+            # server was running several threads at once, and those tools can
+            # wait forever for a lock held by a thread that does not exist in the
+            # copy. A process stuck forever is exactly what we must avoid.
+            os.write(
+                2,
+                f"Diff export process failed:\n{traceback.format_exc()}".encode(),
+            )
+        finally:
+            # Always stop here, and always with the code 0. The first process of
+            # the container reads this code, and gunicorn shuts the whole server
+            # down when it reads a 3 or a 4.
             os._exit(0)

--- a/app/api_alpha/tests/buildings/test_diff.py
+++ b/app/api_alpha/tests/buildings/test_diff.py
@@ -2,6 +2,7 @@ import csv
 import datetime
 import io
 import json
+import os
 import uuid
 
 from batid.models import Address, Building, City, Organization, UserProfile
@@ -799,6 +800,33 @@ class DiffTest(TransactionTestCase):
         self.assertEqual(rows[1]["event_type"], "reactivation")
         self.assertListEqual(json.loads(rows[1]["addresses_id"]), ["ADDRESS_ID_1"])
         self.assertEqual(rows[1]["username"], "marcella")
+
+    def test_diff_leaves_no_leftover_process(self):
+        """
+        Input: a building created after the 'since' threshold, and a diff request
+        whose streaming response is read until the end.
+        Expected: the CSV contains the building, and once the download is over the
+        calling process has no child process left at all, so os.waitpid reports
+        that there is nothing to wait for. The export process must have been
+        handed over to the first process of the container instead of staying
+        attached here, otherwise finished processes pile up and eventually make
+        the endpoint unable to start any new process.
+        """
+        Building.objects.create(rnb_id="B1", event_type="creation")
+        threshold = Building.objects.get(rnb_id="B1").sys_period.lower
+        Building.objects.create(rnb_id="B2", event_type="creation")
+
+        params = urlencode({"since": threshold.isoformat()})
+        r = self.client.get(f"/api/alpha/buildings/diff/?{params}")
+
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("B2", get_content_from_streaming_response(r))
+
+        # os.waitpid only raises ChildProcessError when the calling process has
+        # no child left. If the export process were still attached to us, it
+        # would be reported here instead (either as running or as finished).
+        with self.assertRaises(ChildProcessError):
+            os.waitpid(-1, os.WNOHANG)
 
 
 class DiffInseeCodeTest(TransactionTestCase):


### PR DESCRIPTION
## Le problème

L'endpoint `/api/alpha/buildings/diff/` ne répond plus. Sentry remonte 2331 erreurs : [RNB-COEUR-MM](https://sentry.incubateur.net/organizations/betagouv/issues/RNB-COEUR-MM).

Discussion à l'origine de ce travail : [Mattermost](https://mattermost.incubateur.net/fab-geocommuns/pl/x3njkx1ohbf6fdi5sujyznn47h).

L'erreur arrive au moment où le code crée un nouveau processus. Le système refuse. Il n'y a plus de place libre.

Rien n'a été déployé ce jour-là. Toutes les erreurs viennent du même conteneur, allumé depuis deux semaines. Le problème s'est donc accumulé lentement, puis a franchi une limite. C'est pour ça que l'endpoint reste cassé au lieu de se rétablir tout seul.

Pourquoi cet endpoint crée-t-il des processus ? L'export SQL est long. On veut envoyer le CSV au client pendant que la requête tourne encore. Un processus séparé fait l'export et écrit dans un tuyau. Le serveur web lit ce tuyau et envoie le résultat au client.

Ce processus séparé fuyait de deux façons différentes.

### Fuite 1 : chaque téléchargement laissait un processus derrière lui

Un processus terminé ne disparaît pas tout seul. Son parent doit venir récupérer son code de sortie. Sans ça, le processus reste dans la liste du système et continue d'occuper une place.

Gunicorn ne fait jamais cette récupération pour les processus créés par notre propre code. Résultat : un téléchargement laissait un processus mort derrière lui, et ce définitivement.

### Fuite 2 : une annulation transformait le processus en second serveur web

Le processus d'export ne s'arrêtait que si tout se passait bien jusqu'au bout.

Quand un client annulait son téléchargement, une erreur remontait. Elle traversait Django, puis gunicorn. Or ce processus est une copie du serveur web. Il a hérité de la connexion réseau sur laquelle le serveur écoute.

Il se mettait donc à répondre à des requêtes en parallèle du vrai serveur. Sans jamais s'arrêter. Et en gardant une connexion à la base ouverte.

## Le correctif

### Pour la fuite 1

Le processus d'export est maintenant créé en deux temps.

On crée d'abord un processus intermédiaire. Son seul travail est de créer le processus d'export, puis de s'arrêter aussitôt. Le serveur web récupère cet intermédiaire tout de suite. Ça ne coûte rien, puisqu'il s'arrête immédiatement.

Le processus d'export se retrouve alors sans parent. Le système le confie automatiquement au tout premier processus du conteneur. Et celui-là, lui, fait le ménage. Plus rien ne s'accumule.

### Pour la fuite 2

Tout le travail du processus d'export est maintenant encadré. Il se termine toujours par un arrêt explicite, quoi qu'il arrive. Une annulation du client est traitée comme un cas normal, pas comme une erreur.

## Deux points à relire de près

**Le processus d'export sort toujours avec le code 0.** Ce n'est pas un détail cosmétique. Gunicorn lit le code de sortie de tous les processus qu'il récupère. S'il lit un 3 ou un 4, il arrête le serveur en entier.

**Les erreurs de l'export partent désormais dans les logs du conteneur, et non plus dans Sentry.** C'est volontaire. Ce processus est une copie prise pendant que le serveur tournait avec plusieurs threads. Le SDK Sentry peut s'y bloquer indéfiniment, en attendant un verrou tenu par un thread qui n'existe plus dans la copie. Un processus bloqué pour toujours, c'est précisément ce qu'on corrige ici. Je peux remettre Sentry avec un délai d'attente maximum si vous préférez garder la visibilité.

Au passage : quand la création d'un processus échoue, on referme maintenant les deux bouts du tuyau. Avant, chaque échec laissait deux fichiers ouverts derrière lui.

## Tests

`docker exec web python manage.py test api_alpha.tests.buildings.test_diff` → 21 tests, tout passe.

Le nouveau test `test_diff_leaves_no_leftover_process` a été lancé contre l'ancien code. Il échoue bien dessus. Il couvre donc réellement la fuite 1, et pas juste le chemin nominal.

La fuite 2 n'a pas de test automatique. Le reproduire ferait tourner du code de serveur web à l'intérieur du processus de test, ce qui est trop instable. Elle est couverte par la structure du code, pas par une assertion.

## Avant de merger

- [ ] **Il faut redémarrer le conteneur de prod.** Ce correctif empêche les nouvelles fuites. Il ne libère pas les processus déjà accumulés. Tant qu'on n'a pas redémarré, l'endpoint reste cassé.
- [ ] Optionnel : poser une limite de processus sur le service `web`. Le prochain problème de ce genre échouerait alors franchement, au lieu de tuer un endpoint en silence. Pas fait ici, parce que ça touche la configuration de prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
